### PR TITLE
[ISSUE-53] 공통 바텀시트 생성

### DIFF
--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/utils/BottomSheet.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/utils/BottomSheet.kt
@@ -1,0 +1,103 @@
+package com.yapp.growth.presentation.ui.utils
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * How to use?
+ * val sheetState = rememberBottomSheetState(
+ *      initialValue = BottomSheetValue.Collapsed
+ * )
+ * val scaffoldState = rememberBottomSheetScaffoldState(
+ *      bottomSheetState = sheetState
+ * )
+ * val scope = rememberCoroutineScope()
+ *      BottomSheetScreen(
+ *          sheetState = sheetState, scaffoldState = scaffoldState, scope = scope
+ *      )
+ */
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun BottomSheetScreen(
+    sheetState: BottomSheetState, scaffoldState: BottomSheetScaffoldState, scope: CoroutineScope
+) {
+    BottomSheetScaffold(sheetBackgroundColor = Color.Transparent,
+        sheetPeekHeight = 0.dp,
+        scaffoldState = scaffoldState,
+        sheetContent = {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.7f))
+                    .clickable(sheetState.isExpanded) {
+                        scope.launch {
+                            sheetState.collapse()
+                        }
+                    }
+            ) {
+                Surface(
+                    modifier = Modifier
+                        .height(200.dp)
+                        .align(Alignment.BottomCenter)
+                        .clickable(false) { },
+                    shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color.White)
+                    ) {
+                        Text(
+                            modifier = Modifier
+                                .clickable(sheetState.isExpanded) {
+                                    scope.launch { sheetState.collapse() }
+                                },
+                            text = "Bottom sheet",
+                            fontSize = 40.sp
+                        )
+                    }
+                }
+            }
+        }) {
+        HomeButton(sheetState, scope)
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun HomeButton(sheetState: BottomSheetState, scope: CoroutineScope) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(RoundedCornerShape(10.dp)),
+        contentAlignment = Alignment.Center
+    ) {
+        Button(onClick = {
+            scope.launch {
+                if (sheetState.isCollapsed) {
+                    sheetState.expand()
+                } else {
+                    sheetState.collapse()
+                }
+            }
+        }) {
+            Text(text = "Bottom sheet state: ${sheetState.currentValue}")
+        }
+
+    }
+}

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/utils/BottomSheet.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/utils/BottomSheet.kt
@@ -36,7 +36,8 @@ import kotlinx.coroutines.launch
 fun BottomSheetScreen(
     sheetState: BottomSheetState, scaffoldState: BottomSheetScaffoldState, scope: CoroutineScope
 ) {
-    BottomSheetScaffold(sheetBackgroundColor = Color.Transparent,
+    BottomSheetScaffold(
+        sheetBackgroundColor = Color.Transparent,
         sheetPeekHeight = 0.dp,
         scaffoldState = scaffoldState,
         sheetContent = {


### PR DESCRIPTION
## ISSUE
- resolved #53 

<br>

## 작업 내용
- 공통으로 쓸 수 있는 바텀시트를 만들었습니다.
- 주의깊게 볼 점은 rememberBottomSheetState, rememberBottomSheetScaffoldState, rememberCoroutineScope 요 3가지입니다.
- 화면마다 커스텀 할 때 xxxBottomSheetScreen 으로 BottomSheetScreen 을 커스텀해서 쓰면 될 것 같아요
- 영역별로 Modifier.clickable 을 설정해두었는데 가져다 쓸 때 바꿔주면 됩니다.


<br>

## 실행 화면

| Screen Shot |
| ----------- |
| ![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/33443660/175976210-bf8ac22a-63f5-422b-8cd4-833a46e712f1.gif)|


<br>

## Check List
- [x] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [x] CI/CD 통과 여부
- [x] 1명 이상의 Approve 확인 후 Merge
- [x] 관련 이슈 연결
