### PR TITLE
[ISSUE-SideEffect] 카카오 로그인 로직 수정 

### DIFF
--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/login/LoginActivity.kt
@@ -7,15 +7,12 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.lifecycle.lifecycleScope
+import androidx.compose.runtime.LaunchedEffect
 import com.yapp.growth.presentation.R
 import com.yapp.growth.presentation.theme.PlanzTheme
-import com.yapp.growth.presentation.ui.login.LoginContract.LoginState
-import com.yapp.growth.presentation.ui.login.LoginContract.LoginViewState
 import com.yapp.growth.presentation.ui.main.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class LoginActivity : ComponentActivity() {
@@ -25,15 +22,29 @@ class LoginActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        lifecycleScope.launch {
-            viewModel.viewState.collect { state ->
-                handleEvent(state)
-            }
-        }
-
         setContent {
             PlanzTheme {
-                LoginScreen(onClick = { viewModel.requestLogin(this@LoginActivity) })
+                LoginScreen(onClick = { viewModel.setEvent(LoginContract.LoginEvent.OnClickKakaoLoginButton(this@LoginActivity)) })
+            }
+
+            LaunchedEffect(key1 = viewModel.effect) {
+                viewModel.effect.collect { effect ->
+                    when (effect) {
+                        is LoginContract.LoginSideEffect.MoveToMain -> {
+                            MainActivity.startActivity(this@LoginActivity)
+                            finish()
+                        }
+
+                        is LoginContract.LoginSideEffect.LoginFailed -> {
+                            Toast.makeText(
+                                this@LoginActivity,
+                                R.string.message_kakao_login_failed,
+                                Toast.LENGTH_SHORT
+                            ).show()
+
+                        }
+                    }
+                }
             }
         }
     }
@@ -46,16 +57,4 @@ class LoginActivity : ComponentActivity() {
         }
     }
 
-    private fun handleEvent(state: LoginViewState) = when (state.loginState) {
-        LoginState.SUCCESS -> {
-            MainActivity.startActivity(this)
-            finish()
-        }
-
-        LoginState.REQUIRED -> {
-            Toast.makeText(this, R.string.message_kakao_login_failed, Toast.LENGTH_SHORT).show()
-        }
-
-        else -> {}
-    }
 }

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/login/LoginActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.LaunchedEffect
 import com.yapp.growth.presentation.R
 import com.yapp.growth.presentation.theme.PlanzTheme
 import com.yapp.growth.presentation.ui.main.MainActivity
+import com.yapp.growth.presentation.ui.login.LoginContract.*
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collect
 
@@ -30,12 +31,12 @@ class LoginActivity : ComponentActivity() {
             LaunchedEffect(key1 = viewModel.effect) {
                 viewModel.effect.collect { effect ->
                     when (effect) {
-                        is LoginContract.LoginSideEffect.MoveToMain -> {
+                        is LoginSideEffect.MoveToMain -> {
                             MainActivity.startActivity(this@LoginActivity)
                             finish()
                         }
 
-                        is LoginContract.LoginSideEffect.LoginFailed -> {
+                        is LoginSideEffect.LoginFailed -> {
                             Toast.makeText(
                                 this@LoginActivity,
                                 R.string.message_kakao_login_failed,

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/login/LoginContract.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/login/LoginContract.kt
@@ -1,5 +1,6 @@
 package com.yapp.growth.presentation.ui.login
 
+import android.content.Context
 import com.yapp.growth.base.ViewEvent
 import com.yapp.growth.base.ViewSideEffect
 import com.yapp.growth.base.ViewState
@@ -10,11 +11,12 @@ class LoginContract {
     ): ViewState
 
     sealed class LoginSideEffect: ViewSideEffect {
-
+        object MoveToMain: LoginSideEffect()
+        object LoginFailed: LoginSideEffect()
     }
 
     sealed class LoginEvent: ViewEvent {
-
+        data class OnClickKakaoLoginButton(val context: Context): LoginEvent()
     }
 
     enum class LoginState {

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/login/LoginScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/login/LoginViewModel.kt
@@ -14,27 +14,26 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-): BaseViewModel<LoginViewState, LoginSideEffect, LoginEvent>(
-    LoginViewState()) {
+) : BaseViewModel<LoginViewState, LoginSideEffect, LoginEvent>(
+    LoginViewState()
+) {
 
     @Inject
     lateinit var kakaoLoginSdk: LoginSdk
 
     override fun handleEvents(event: LoginEvent) {
-        TODO("Not yet implemented")
-    }
-
-    fun requestLogin(context: Context) {
-        viewModelScope.launch {
-
-            runCatching { kakaoLoginSdk.login(context) }
-                .onSuccess { setLoginState(true) }
-                .onError { setLoginState(false) }
+        when (event) {
+            is LoginEvent.OnClickKakaoLoginButton -> requestLogin(event.context)
         }
     }
 
-    private fun setLoginState(isLogin: Boolean) {
-        if(isLogin) updateState { copy(loginState = LoginState.SUCCESS) }
-        else updateState { copy(loginState = LoginState.REQUIRED) }
+    private fun requestLogin(context: Context) {
+        viewModelScope.launch {
+
+            runCatching { kakaoLoginSdk.login(context) }
+                .onSuccess { sendEffect({ LoginSideEffect.MoveToMain }) }
+                .onError { sendEffect({ LoginSideEffect.LoginFailed }) }
+        }
     }
+
 }

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/splash/SplashActivity.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/splash/SplashActivity.kt
@@ -7,12 +7,12 @@ import android.view.View
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.lifecycleScope
 import com.yapp.growth.presentation.theme.PlanzTheme
 import com.yapp.growth.presentation.ui.login.LoginActivity
 import com.yapp.growth.presentation.ui.main.MainActivity
-import com.yapp.growth.presentation.ui.splash.SplashContract.LoginState
-import com.yapp.growth.presentation.ui.splash.SplashContract.SplashViewState
+import com.yapp.growth.presentation.ui.splash.SplashContract.*
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -35,9 +35,6 @@ class SplashActivity : ComponentActivity() {
 
         lifecycleScope.launch {
             viewModel.checkValidLoginToken()
-            viewModel.viewState.collect { state ->
-                handleIntent(state)
-            }
         }
     }
 
@@ -46,13 +43,16 @@ class SplashActivity : ComponentActivity() {
             PlanzTheme {
                 SplashScreen()
             }
-        }
-    }
 
-    private fun handleIntent(state: SplashViewState) = when (state.loginState) {
-        LoginState.SUCCESS -> moveToMain()
-        LoginState.REQUIRED -> moveToLogin()
-        else -> {}
+            LaunchedEffect(key1 = viewModel.effect) {
+                viewModel.effect.collect { effect ->
+                    when (effect) {
+                        is SplashSideEffect.MoveToMain -> moveToMain()
+                        is SplashSideEffect.LoginFailed -> moveToLogin()
+                    }
+                }
+            }
+        }
     }
 
     private fun moveToMain() {

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/splash/SplashContract.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/splash/SplashContract.kt
@@ -10,6 +10,8 @@ class SplashContract {
     ) : ViewState
 
     sealed class SplashSideEffect : ViewSideEffect {
+        object MoveToMain: SplashSideEffect()
+        object LoginFailed: SplashSideEffect()
     }
 
     sealed class SplashEvent : ViewEvent {

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/splash/SplashViewModel.kt
@@ -22,10 +22,10 @@ class SplashViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching {
                 val isValidLoginToken = kakaoLoginSdk.isValidAccessToken()
-                if (isValidLoginToken) updateState { copy(loginState = LoginState.SUCCESS) }
-                else updateState { copy(loginState = LoginState.REQUIRED) }
+                if (isValidLoginToken) sendEffect({ SplashSideEffect.MoveToMain })
+                else sendEffect({ SplashSideEffect.LoginFailed })
             }.onError {
-                updateState { copy(loginState = LoginState.REQUIRED) }
+                sendEffect({ SplashSideEffect.LoginFailed })
             }
 
         }


### PR DESCRIPTION
## ISSUE
- 카카오 로그인 부분 SideEffect, State, Event 사용 로직 수정
- SplashActivity, LoginActivity 두 부분 모두 수정했습니다

<br>

## Check List
- [x] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [x] CI/CD 통과 여부
- [x] 1명 이상의 Approve 확인 후 Merge
- [x] 관련 이슈 연결
