### PR TITLE
[ISSUE-78] Api Key 코드 리펙토링

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,6 @@ android {
         versionCode = Configs.VERSION_CODE
         versionName = Configs.VERSION_NAME
 
-        getProperty("KAKAO_APP_KEY")?.let { resValue("string", "kakao_sdk_app_key", it) }
     }
 
     signingConfigs {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,6 @@ android {
         versionCode = Configs.VERSION_CODE
         versionName = Configs.VERSION_NAME
 
-        getProperty("KAKAO_O_AUTH")?.let { resValue("string", "kakao_o_auth_scheme", it) }
         getProperty("KAKAO_APP_KEY")?.let { resValue("string", "kakao_sdk_app_key", it) }
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,9 +31,8 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <!-- Redirect URI: "kakao${NATIVE_APP_KEY}://oauth" -->
                 <data android:host="oauth"
-                    android:scheme="${KAKAO_O_AUTH}" />
+                    android:scheme="kakao${KAKAO_APP_KEY}" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/yapp/growth/di/AppModule.kt
+++ b/app/src/main/java/com/yapp/growth/di/AppModule.kt
@@ -16,10 +16,6 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object AppModule {
 
-    @Named("BaseUrl")
-    @Provides
-    fun provideBaseUrl(): String = "https://api.github.com"
-
     @Provides
     @Singleton
     fun provideNetworkSettings(): NetworkSettings {

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id(app.Plugins.KOTLIN_ANDROID)
     id(app.Plugins.KOTLIN_KAPT)
     id(app.Plugins.HILT_ANDROID)
+    id(app.Plugins.SECRETS_GRADLE)
 }
 
 android {

--- a/data/src/main/java/com/yapp/growth/data/di/DataModule.kt
+++ b/data/src/main/java/com/yapp/growth/data/di/DataModule.kt
@@ -2,6 +2,7 @@ package com.yapp.growth.data.di
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.yapp.growth.data.BuildConfig
 import com.yapp.growth.data.api.GrowthApi
 import dagger.Module
 import dagger.Provides
@@ -23,7 +24,7 @@ internal class DataModule {
     fun provideRetrofit(
         okHttpClient: OkHttpClient,
         jsonAdapterFactory: Converter.Factory,
-        @Named("BaseUrl") baseUrl: String
+        baseUrl: String = BuildConfig.BASE_URL
     ): Retrofit =
         Retrofit.Builder()
             .client(okHttpClient)


### PR DESCRIPTION
## ISSUE
- resolved #78 

<br>

## 작업 내용
- KAKAO_O_AUTH 를 삭제하고 KAKAO_APP_KEY 로 관리하도록 수정했습니다. (카카오 앱키 재발급 받았습니다)
- 기존에 build.gradle 에서 property 로 가져오는 로직을 삭제하고 secrets 라이브러리를 통해 BuildConfig 로 대체했습니다.
- AppModule 에서 BaseUrl 을 Provide 하는 로직을 삭제하고 BuildConfig 로 대체했습니다.

<br>

## Check List
- [x] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [x] CI/CD 통과 여부
- [x] 1명 이상의 Approve 확인 후 Merge
- [x] 관련 이슈 연결
