### PR TITLE
[ISSUE-123] 로그아웃, 이용약관 - 개인정보 처리방침 화면 추가

### DIFF
--- a/presentation/src/main/java/com/yapp/growth/presentation/component/PlanzWebView.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/component/PlanzWebView.kt
@@ -1,0 +1,41 @@
+package com.yapp.growth.presentation.component
+
+import android.annotation.SuppressLint
+import android.view.ViewGroup
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+fun PlanzWebView(url: String) {
+    AndroidView(
+        modifier = Modifier.fillMaxSize(),
+        factory = {
+            WebView(it).apply {
+                settings.builtInZoomControls = true
+                settings.domStorageEnabled = true
+                settings.javaScriptEnabled = true
+
+                scrollBarStyle = WebView.SCROLLBARS_OUTSIDE_INSET
+
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
+
+                webViewClient = object : WebViewClient() {
+                    override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+                        return false
+                    }
+                }
+
+                loadUrl(url)
+            }
+        }
+    )
+}

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzScreen.kt
@@ -52,6 +52,7 @@ import com.yapp.growth.presentation.ui.main.manage.respond.RespondPlanScreen
 import com.yapp.growth.presentation.ui.main.manage.respond.result.RespondPlanCompleteScreen
 import com.yapp.growth.presentation.ui.main.manage.respond.result.RespondPlanRejectScreen
 import com.yapp.growth.presentation.ui.main.myPage.MyPageScreen
+import com.yapp.growth.presentation.ui.main.privacyPolicy.PrivacyPolicyScreen
 import com.yapp.growth.presentation.ui.main.sample.SampleScreen
 import timber.log.Timber
 
@@ -160,7 +161,14 @@ fun PlanzScreen(
 
             composable(route = PlanzScreenRoute.MY_PAGE.route) {
                 MyPageScreen(
-                    exitMyPageScreen = { navController.popBackStack() }
+                    exitMyPageScreen = { navController.popBackStack() },
+                    navigateToPolicyScreen = { navController.navigate(PlanzScreenRoute.PRIVACY_POLICY.route) },
+                )
+            }
+
+            composable(route = PlanzScreenRoute.PRIVACY_POLICY.route) {
+                PrivacyPolicyScreen (
+                    exitPrivacyPolicyScreen = { navController.popBackStack() }
                 )
             }
 
@@ -299,6 +307,7 @@ enum class PlanzScreenRoute(val route: String) {
     MANAGE_PLAN("manage-plan"),
     CREATE_PLAN("create-plan"),
     MY_PAGE("my-page"),
+    PRIVACY_POLICY("privacy-policy"),
     DETAIL_PLAN("detail-plan"),
     SAMPLE("sample"),
     RESPOND_PLAN("respond-plan"),

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzScreen.kt
@@ -54,6 +54,7 @@ import com.yapp.growth.presentation.ui.main.manage.respond.result.RespondPlanRej
 import com.yapp.growth.presentation.ui.main.myPage.MyPageScreen
 import com.yapp.growth.presentation.ui.main.privacyPolicy.PrivacyPolicyScreen
 import com.yapp.growth.presentation.ui.main.sample.SampleScreen
+import com.yapp.growth.presentation.ui.main.terms.TermsScreen
 import timber.log.Timber
 
 @Composable
@@ -163,12 +164,19 @@ fun PlanzScreen(
                 MyPageScreen(
                     exitMyPageScreen = { navController.popBackStack() },
                     navigateToPolicyScreen = { navController.navigate(PlanzScreenRoute.PRIVACY_POLICY.route) },
+                    navigateToTermsScreen = { navController.navigate(PlanzScreenRoute.TERMS.route) },
                 )
             }
 
             composable(route = PlanzScreenRoute.PRIVACY_POLICY.route) {
                 PrivacyPolicyScreen (
                     exitPrivacyPolicyScreen = { navController.popBackStack() }
+                )
+            }
+
+            composable(route = PlanzScreenRoute.TERMS.route) {
+                TermsScreen (
+                    exitTermsScreen = { navController.popBackStack() }
                 )
             }
 
@@ -308,6 +316,7 @@ enum class PlanzScreenRoute(val route: String) {
     CREATE_PLAN("create-plan"),
     MY_PAGE("my-page"),
     PRIVACY_POLICY("privacy-policy"),
+    TERMS("terms"),
     DETAIL_PLAN("detail-plan"),
     SAMPLE("sample"),
     RESPOND_PLAN("respond-plan"),

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageContract.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageContract.kt
@@ -14,11 +14,13 @@ class MyPageContract {
 
     sealed class MyPageSideEffect : ViewSideEffect {
         object MoveToLogin : MyPageSideEffect()
+        object NavigateToPolicy : MyPageSideEffect()
         object ExitMyPageScreen : MyPageSideEffect()
         data class ShowToast(val msg: String) : MyPageSideEffect()
     }
 
     sealed class MyPageEvent : ViewEvent {
+        object OnPolicyClicked : MyPageEvent()
         object OnLogoutClicked : MyPageEvent()
         object OnSignUpClicked : MyPageEvent()
         object OnWithDrawClicked : MyPageEvent()

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageContract.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageContract.kt
@@ -15,6 +15,7 @@ class MyPageContract {
     sealed class MyPageSideEffect : ViewSideEffect {
         object MoveToLogin : MyPageSideEffect()
         object ExitMyPageScreen : MyPageSideEffect()
+        data class ShowToast(val msg: String) : MyPageSideEffect()
     }
 
     sealed class MyPageEvent : ViewEvent {

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageContract.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageContract.kt
@@ -14,12 +14,14 @@ class MyPageContract {
 
     sealed class MyPageSideEffect : ViewSideEffect {
         object MoveToLogin : MyPageSideEffect()
+        object NavigateToTerms : MyPageSideEffect()
         object NavigateToPolicy : MyPageSideEffect()
         object ExitMyPageScreen : MyPageSideEffect()
         data class ShowToast(val msg: String) : MyPageSideEffect()
     }
 
     sealed class MyPageEvent : ViewEvent {
+        object OnTermsClicked : MyPageEvent()
         object OnPolicyClicked : MyPageEvent()
         object OnLogoutClicked : MyPageEvent()
         object OnSignUpClicked : MyPageEvent()

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageScreen.kt
@@ -60,6 +60,7 @@ import com.yapp.growth.presentation.ui.main.myPage.MyPageContract.MyPageSideEffe
 @Composable
 fun MyPageScreen(
     viewModel: MyPageViewModel = hiltViewModel(),
+    navigateToPolicyScreen: () -> Unit,
     exitMyPageScreen: () -> Unit,
 ) {
 
@@ -107,7 +108,10 @@ fun MyPageScreen(
                         )
                     }
                     Spacer(modifier = Modifier.height(20.dp))
-                    MyPageCustomerService(context = context)
+                    MyPageCustomerService(
+                        context = context,
+                        onPolicyClicked = navigateToPolicyScreen
+                    )
                     Spacer(modifier = Modifier.height(24.dp))
                     if (viewState.loginState == LoginState.LOGIN) {
                         MyPageAccountManagement(
@@ -208,7 +212,8 @@ fun MyPageUserInfo(
 
 @Composable
 fun MyPageCustomerService(
-    context: Context
+    context: Context,
+    onPolicyClicked: () -> Unit,
 ) {
     val versionName = context.packageManager.getPackageInfo(context.packageName, 0).versionName
 
@@ -221,7 +226,7 @@ fun MyPageCustomerService(
         )
         MyPageItem(
             content = stringResource(id = R.string.my_page_privacy_policy_text),
-            onClick = { /* TODO */ }
+            onClick = { onPolicyClicked() }
         )
         MyPageItem(
             content = stringResource(id = R.string.my_page_version_info_text) + " $versionName",
@@ -345,7 +350,9 @@ fun MyPageDialog(
 @Composable
 fun PreviewMyPageScreen() {
     PlanzTheme {
-        MyPageScreen(exitMyPageScreen = { })
+        MyPageScreen(navigateToPolicyScreen = { /*TODO*/ }) {
+            
+        }
     }
 }
 

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageScreen.kt
@@ -61,6 +61,7 @@ import com.yapp.growth.presentation.ui.main.myPage.MyPageContract.MyPageSideEffe
 fun MyPageScreen(
     viewModel: MyPageViewModel = hiltViewModel(),
     navigateToPolicyScreen: () -> Unit,
+    navigateToTermsScreen: () -> Unit,
     exitMyPageScreen: () -> Unit,
 ) {
 
@@ -76,6 +77,12 @@ fun MyPageScreen(
                 }
                 is MyPageSideEffect.ExitMyPageScreen -> {
                     exitMyPageScreen()
+                }
+                is MyPageSideEffect.NavigateToPolicy -> {
+                    navigateToPolicyScreen()
+                }
+                is MyPageSideEffect.NavigateToTerms -> {
+                    navigateToTermsScreen()
                 }
                 is MyPageSideEffect.ShowToast -> {
                     Toast.makeText(context, effect.msg, Toast.LENGTH_SHORT).show()
@@ -110,7 +117,8 @@ fun MyPageScreen(
                     Spacer(modifier = Modifier.height(20.dp))
                     MyPageCustomerService(
                         context = context,
-                        onPolicyClicked = navigateToPolicyScreen
+                        onPolicyClicked = { viewModel.setEvent(MyPageEvent.OnPolicyClicked) },
+                        onTermsClicked = { viewModel.setEvent(MyPageEvent.OnTermsClicked) },
                     )
                     Spacer(modifier = Modifier.height(24.dp))
                     if (viewState.loginState == LoginState.LOGIN) {
@@ -213,6 +221,7 @@ fun MyPageUserInfo(
 @Composable
 fun MyPageCustomerService(
     context: Context,
+    onTermsClicked: () -> Unit,
     onPolicyClicked: () -> Unit,
 ) {
     val versionName = context.packageManager.getPackageInfo(context.packageName, 0).versionName
@@ -222,11 +231,11 @@ fun MyPageCustomerService(
         Spacer(modifier = Modifier.height(12.dp))
         MyPageItem(
             content = stringResource(id = R.string.my_page_terms_text),
-            onClick = { /* TODO */ }
+            onClick = onTermsClicked
         )
         MyPageItem(
             content = stringResource(id = R.string.my_page_privacy_policy_text),
-            onClick = { onPolicyClicked() }
+            onClick = onPolicyClicked
         )
         MyPageItem(
             content = stringResource(id = R.string.my_page_version_info_text) + " $versionName",
@@ -350,9 +359,11 @@ fun MyPageDialog(
 @Composable
 fun PreviewMyPageScreen() {
     PlanzTheme {
-        MyPageScreen(navigateToPolicyScreen = { /*TODO*/ }) {
-            
-        }
+        MyPageScreen(
+            navigateToPolicyScreen = {  },
+            navigateToTermsScreen = {  },
+            exitMyPageScreen = { }
+        )
     }
 }
 

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageScreen.kt
@@ -2,6 +2,7 @@ package com.yapp.growth.presentation.ui.main.myPage
 
 import android.app.Activity
 import android.content.Context
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -74,6 +75,9 @@ fun MyPageScreen(
                 }
                 is MyPageSideEffect.ExitMyPageScreen -> {
                     exitMyPageScreen()
+                }
+                is MyPageSideEffect.ShowToast -> {
+                    Toast.makeText(context, effect.msg, Toast.LENGTH_SHORT).show()
                 }
             }
         }

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageViewModel.kt
@@ -34,6 +34,9 @@ class MyPageViewModel @Inject constructor(
 
     override fun handleEvents(event: MyPageEvent) {
         when (event) {
+            is MyPageEvent.OnTermsClicked -> {
+                sendEffect({ MyPageSideEffect.NavigateToTerms })
+            }
             is MyPageEvent.OnPolicyClicked -> {
                 sendEffect({ MyPageSideEffect.NavigateToPolicy })
             }

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageViewModel.kt
@@ -69,29 +69,40 @@ class MyPageViewModel @Inject constructor(
                     sendEffect({ MyPageSideEffect.MoveToLogin })
                 }
                 .onError {
-                    sendEffect({ MyPageSideEffect.ShowToast(resourcesProvider.getString(R.string.my_page_logout_error_text))})
+                    sendEffect({ MyPageSideEffect.ShowToast(resourcesProvider.getString(R.string.my_page_logout_error_text)) })
                 }
         }
     }
 
     private fun fetchUserInfo() {
         viewModelScope.launch {
-            getUserInfoUseCase.invoke()
-                .onSuccess {
-                    updateState {
-                        copy(
-                            loadState = MyPageContract.LoadState.Idle,
-                            userName = it.userName
-                        )
+            val cacheInfo = getUserInfoUseCase.getCachedUserInfo()
+
+            if(cacheInfo == null) {
+                getUserInfoUseCase.invoke()
+                    .onSuccess {
+                        updateState {
+                            copy(
+                                loadState = MyPageContract.LoadState.Idle,
+                                userName = it.userName
+                            )
+                        }
                     }
-                }
-                .onError {
-                    updateState {
-                        copy(
-                            loadState = MyPageContract.LoadState.Error
-                        )
+                    .onError {
+                        updateState {
+                            copy(
+                                loadState = MyPageContract.LoadState.Error
+                            )
+                        }
                     }
+            } else {
+                updateState {
+                    copy(
+                        loadState = MyPageContract.LoadState.Idle,
+                        userName = cacheInfo.userName
+                    )
                 }
+            }
         }
     }
 

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageViewModel.kt
@@ -34,7 +34,9 @@ class MyPageViewModel @Inject constructor(
 
     override fun handleEvents(event: MyPageEvent) {
         when (event) {
-            // TODO : 이용약관, 개인정보 처리 방침, 탈퇴하기 (다이얼로그)
+            is MyPageEvent.OnPolicyClicked -> {
+                sendEffect({ MyPageSideEffect.NavigateToPolicy })
+            }
             is MyPageEvent.OnLogoutClicked -> {
                 logout()
             }

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/privacyPolicy/PrivacyPolicyScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/privacyPolicy/PrivacyPolicyScreen.kt
@@ -1,0 +1,36 @@
+package com.yapp.growth.presentation.ui.main.privacyPolicy
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.yapp.growth.presentation.R
+import com.yapp.growth.presentation.component.PlanzBackAppBar
+import com.yapp.growth.presentation.component.PlanzWebView
+
+@Composable
+fun PrivacyPolicyScreen(
+    exitPrivacyPolicyScreen: () -> Unit,
+) {
+    val url = "https://jalynne.notion.site/7172293b473941ffbc4e1eefdfc85c0e"
+
+    Scaffold(
+        topBar = {
+            PlanzBackAppBar(
+                title = stringResource(id = R.string.privacy_policy_app_bar_text),
+                onBackClick = exitPrivacyPolicyScreen,
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+        ) {
+            PlanzWebView(url = url)
+        }
+    }
+}

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/terms/TermsScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/terms/TermsScreen.kt
@@ -1,0 +1,37 @@
+package com.yapp.growth.presentation.ui.main.terms
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.yapp.growth.presentation.R
+import com.yapp.growth.presentation.component.PlanzBackAppBar
+import com.yapp.growth.presentation.component.PlanzWebView
+
+@Composable
+fun TermsScreen(
+    exitTermsScreen: () -> Unit,
+) {
+
+    val url = "https://jalynne.notion.site/3379be16ecc04914bb98f8a57c980a46"
+
+    Scaffold(
+        topBar = {
+            PlanzBackAppBar(
+                title = stringResource(id = R.string.terms_app_bar_text),
+                onBackClick = exitTermsScreen,
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+        ) {
+            PlanzWebView(url = url)
+        }
+    }
+}

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="my_page_account_management_text">계정 관리</string>
     <string name="my_page_logout_text">로그아웃</string>
     <string name="my_page_withdraw_text">탈퇴하기</string>
+    <string name="my_page_logout_error_text">로그아웃에 실패했습니다. 다시 시도해주세요.</string>
 
     <string name="create_plan_next_button_text">다음</string>
 

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -39,6 +39,10 @@
     <string name="my_page_withdraw_text">탈퇴하기</string>
     <string name="my_page_logout_error_text">로그아웃에 실패했습니다. 다시 시도해주세요.</string>
 
+    <string name="privacy_policy_app_bar_text">개인정보 처리방침</string>
+
+    <string name="terms_app_bar_text">이용약관</string>
+
     <string name="create_plan_next_button_text">다음</string>
 
     <!-- 약속 생성 STEP 1 -->


### PR DESCRIPTION
## ISSUE
- resolved #114 
- resolved #123 

<br>

## 작업 내용
- 로그아웃에 관련된 로직을 추가
- 이용약관 화면 추가
- 개인정보 처리방침 화면 추가
- (마이페이지 -> 이용약관, 개인정보 처리방침) 네비게이션 추가
- 홈, 내 정보 화면에서 캐싱된 유저 정보가 있는지 확인하는 로직 추가


<br>

## 실행 화면

| Screen Shot | Screen Shot |
| ----------- | ----------- |
| <img width="467" alt="image" src="https://user-images.githubusercontent.com/85336456/180649615-893fd7f3-e7d3-476f-b122-5e50892af342.png">            |     <img width="467" alt="image" src="https://user-images.githubusercontent.com/85336456/180649646-edd4228d-9981-4dc4-8935-1d6ed4995c84.png">        |






<br>

## Check List
- [x] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [x] CI/CD 통과 여부
- [ ] 1명 이상의 Approve 확인 후 Merge
- [x] 관련 이슈 연결
