### PR TITLE
[ISSUE-148] 약속 상세보기 화면에 LoadState 적용

### DIFF
--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/detail/DetailPlanContract.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/detail/DetailPlanContract.kt
@@ -7,6 +7,7 @@ import com.yapp.growth.base.ViewState
 
 class DetailPlanContract {
     data class DetailPlanViewState(
+        val loadState: LoadState = LoadState.SUCCESS,
         val title: String = "",
         val category: String = "",
         val date: String = "",

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/detail/DetailPlanContract.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/detail/DetailPlanContract.kt
@@ -1,16 +1,17 @@
 package com.yapp.growth.presentation.ui.main.detail
 
+import com.yapp.growth.base.LoadState
 import com.yapp.growth.base.ViewEvent
 import com.yapp.growth.base.ViewSideEffect
 import com.yapp.growth.base.ViewState
 
 class DetailPlanContract {
     data class DetailPlanViewState(
-        val title: String? = null,
-        val category: String? = null,
-        val date: String? = null,
-        val place: String? = null,
-        val member: String? = null,
+        val title: String = "",
+        val category: String = "",
+        val date: String = "",
+        val place: String = "",
+        val member: String = "",
     ) : ViewState
 
     sealed class DetailPlanSideEffect : ViewSideEffect {

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/detail/DetailPlanScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/detail/DetailPlanScreen.kt
@@ -20,8 +20,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.yapp.growth.base.LoadState
 import com.yapp.growth.presentation.R
+import com.yapp.growth.presentation.component.PlanzError
 import com.yapp.growth.presentation.component.PlanzExitAppBar
+import com.yapp.growth.presentation.component.PlanzLoading
 import com.yapp.growth.presentation.theme.*
 import com.yapp.growth.presentation.ui.main.detail.DetailPlanContract.*
 
@@ -52,90 +55,102 @@ fun DetailPlanScreen(
         },
         backgroundColor = Color.White,
     ) { padding ->
-
-        ConstraintLayout(modifier = Modifier.fillMaxSize()) {
-            val (box, icon) = createRefs()
-
-            Box(
-                modifier = Modifier
-                    .constrainAs(box) {
-                        top.linkTo(parent.top)
-                        start.linkTo(parent.start)
-                        bottom.linkTo(parent.bottom)
-                        end.linkTo(parent.end)
-                    }
-                    .padding(horizontal = 20.dp)
-            ) {
-
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .wrapContentHeight()
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(Color(0xFFFBFCFF))
-                        .border(
-                            width = 1.dp,
-                            color = Gray200,
-                            shape = RoundedCornerShape(12.dp)
-                        )
-                        .padding(vertical = 30.dp, horizontal = 24.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
-                ) {
-
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(7.dp),
-                    ) {
-                        Text(
-                            text = viewState.category,
-                            style = PlanzTypography.h1,
-                            color = MainPurple900,
-                        )
-                        Text(
-                            text = viewState.title,
-                            style = PlanzTypography.body2,
-                            color = Gray500,
-                        )
-                    }
-
-                    Divider(color = Gray200, thickness = 1.dp)
-
-                    Column(
-                        modifier = Modifier.padding(horizontal = 6.dp),
-                        verticalArrangement = Arrangement.spacedBy(16.dp)
-                    ) {
-                        DetailItem(
-                            info = stringResource(id = R.string.detail_plan_info_when),
-                            content = viewState.date
-                        )
-                        DetailItem(
-                            info = stringResource(id = R.string.detail_plan_info_place),
-                            content = viewState.place
-                        )
-                        DetailItem(
-                            info = stringResource(id = R.string.detail_plan_info_member),
-                            content = viewState.member
-                        )
-                    }
+        when(viewState.loadState) {
+            LoadState.LOADING -> {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    PlanzLoading()
                 }
             }
+            LoadState.ERROR -> {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    PlanzError()
+                }
+            }
+            LoadState.SUCCESS -> {
+                ConstraintLayout(modifier = Modifier.fillMaxSize()) {
+                    val (box, icon) = createRefs()
 
-            Icon(
-                modifier = Modifier
-                    .constrainAs(icon) {
-                        top.linkTo(box.top)
-                        bottom.linkTo(box.top)
-                        start.linkTo(box.start)
-                        end.linkTo(box.end)
+                    Box(
+                        modifier = Modifier
+                            .constrainAs(box) {
+                                top.linkTo(parent.top)
+                                start.linkTo(parent.start)
+                                bottom.linkTo(parent.bottom)
+                                end.linkTo(parent.end)
+                            }
+                            .padding(horizontal = 20.dp)
+                    ) {
+
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .wrapContentHeight()
+                                .clip(RoundedCornerShape(12.dp))
+                                .background(Color(0xFFFBFCFF))
+                                .border(
+                                    width = 1.dp,
+                                    color = Gray200,
+                                    shape = RoundedCornerShape(12.dp)
+                                )
+                                .padding(vertical = 30.dp, horizontal = 24.dp),
+                            verticalArrangement = Arrangement.spacedBy(16.dp),
+                        ) {
+
+                            Column(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(7.dp),
+                            ) {
+                                Text(
+                                    text = viewState.category,
+                                    style = PlanzTypography.h1,
+                                    color = MainPurple900,
+                                )
+                                Text(
+                                    text = viewState.title,
+                                    style = PlanzTypography.body2,
+                                    color = Gray500,
+                                )
+                            }
+
+                            Divider(color = Gray200, thickness = 1.dp)
+
+                            Column(
+                                modifier = Modifier.padding(horizontal = 6.dp),
+                                verticalArrangement = Arrangement.spacedBy(16.dp)
+                            ) {
+                                DetailItem(
+                                    info = stringResource(id = R.string.detail_plan_info_when),
+                                    content = viewState.date
+                                )
+                                DetailItem(
+                                    info = stringResource(id = R.string.detail_plan_info_place),
+                                    content = viewState.place
+                                )
+                                DetailItem(
+                                    info = stringResource(id = R.string.detail_plan_info_member),
+                                    content = viewState.member
+                                )
+                            }
+                        }
                     }
-                    .padding(bottom = 20.dp),
-                tint = Color.Unspecified,
-                imageVector = ImageVector.vectorResource(R.drawable.icon_plan_detail),
-                contentDescription = null
-            )
-        }
 
+                    Icon(
+                        modifier = Modifier
+                            .constrainAs(icon) {
+                                top.linkTo(box.top)
+                                bottom.linkTo(box.top)
+                                start.linkTo(box.start)
+                                end.linkTo(box.end)
+                            }
+                            .padding(bottom = 20.dp),
+                        tint = Color.Unspecified,
+                        imageVector = ImageVector.vectorResource(R.drawable.icon_plan_detail),
+                        contentDescription = null
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/detail/DetailPlanScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/detail/DetailPlanScreen.kt
@@ -88,12 +88,12 @@ fun DetailPlanScreen(
                         verticalArrangement = Arrangement.spacedBy(7.dp),
                     ) {
                         Text(
-                            text = "${viewState.category}",
+                            text = viewState.category,
                             style = PlanzTypography.h1,
                             color = MainPurple900,
                         )
                         Text(
-                            text = "${viewState.title}",
+                            text = viewState.title,
                             style = PlanzTypography.body2,
                             color = Gray500,
                         )
@@ -107,15 +107,15 @@ fun DetailPlanScreen(
                     ) {
                         DetailItem(
                             info = stringResource(id = R.string.detail_plan_info_when),
-                            content = "${viewState.date}"
+                            content = viewState.date
                         )
                         DetailItem(
                             info = stringResource(id = R.string.detail_plan_info_place),
-                            content = "${viewState.place}"
+                            content = viewState.place
                         )
                         DetailItem(
                             info = stringResource(id = R.string.detail_plan_info_member),
-                            content = "${viewState.member}"
+                            content = viewState.member
                         )
                     }
                 }

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/detail/DetailPlanViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/detail/DetailPlanViewModel.kt
@@ -19,7 +19,7 @@ import javax.inject.Inject
 @HiltViewModel
 class DetailPlanViewModel @Inject constructor(
     private val getFixedPlanUseCase: GetFixedPlanUseCase,
-    private val savedStateHandle: SavedStateHandle,
+    savedStateHandle: SavedStateHandle,
 ) :
     BaseViewModel<DetailPlanViewState, DetailPlanSideEffect, DetailPlanEvent>(
         DetailPlanViewState()

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/detail/DetailPlanViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/detail/DetailPlanViewModel.kt
@@ -1,6 +1,5 @@
 package com.yapp.growth.presentation.ui.main.detail
 
-import android.annotation.SuppressLint
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.yapp.growth.base.BaseViewModel
@@ -10,10 +9,9 @@ import com.yapp.growth.presentation.ui.main.KEY_PLAN_ID
 import com.yapp.growth.presentation.ui.main.detail.DetailPlanContract.DetailPlanEvent
 import com.yapp.growth.presentation.ui.main.detail.DetailPlanContract.DetailPlanSideEffect
 import com.yapp.growth.presentation.ui.main.detail.DetailPlanContract.DetailPlanViewState
+import com.yapp.growth.presentation.util.toDayAndHour
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import java.text.SimpleDateFormat
-import java.util.*
 import javax.inject.Inject
 
 @HiltViewModel
@@ -38,7 +36,6 @@ class DetailPlanViewModel @Inject constructor(
         }
     }
 
-    @SuppressLint("SimpleDateFormat")
     private fun fetchPlan(planId: Long) {
         viewModelScope.launch {
             val result = (getFixedPlanUseCase.invoke(planId))
@@ -48,21 +45,13 @@ class DetailPlanViewModel @Inject constructor(
                     copy(
                         title = it.title,
                         category = it.category.keyword,
-                        date = convertDate(it.date),
+                        date = it.date.toDayAndHour(),
                         place = it.place,
                         member = convertMemberList(it.members)
                     )
                 }
             }
         }
-    }
-
-    // 2022-11-28 11:30:00 -> 11월 28일 오전 11시
-    @SuppressLint("SimpleDateFormat")
-    private fun convertDate(date: String): String {
-        val tmp: Date = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(date) as Date
-
-        return SimpleDateFormat("M월 d일 aa h시", Locale.KOREA).format(tmp)
     }
 
     private fun convertMemberList(members: List<String>): String {

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeContract.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeContract.kt
@@ -1,6 +1,7 @@
 package com.yapp.growth.presentation.ui.main.home
 
 import com.prolificinteractive.materialcalendarview.CalendarDay
+import com.yapp.growth.base.LoadState
 import com.yapp.growth.base.ViewEvent
 import com.yapp.growth.base.ViewSideEffect
 import com.yapp.growth.base.ViewState
@@ -8,7 +9,7 @@ import com.yapp.growth.domain.entity.Plan
 
 class HomeContract {
     data class HomeViewState(
-        val loadState: LoadState = LoadState.Success,
+        val loadState: LoadState = LoadState.SUCCESS,
         val loginState: LoginState = LoginState.LOGIN,
         val userName: String = "",
         val allPlans: List<Plan.FixedPlan> = emptyList(),
@@ -38,10 +39,6 @@ class HomeContract {
         object OnMonthlyPlanModeClicked : HomeEvent()
         object OnMonthlyPreviousClicked : HomeEvent()
         object OnMonthlyNextClicked : HomeEvent()
-    }
-
-    enum class LoadState {
-        Loading, Success, Error
     }
 
     enum class LoginState {

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.prolificinteractive.materialcalendarview.CalendarDay
+import com.yapp.growth.base.LoadState
 import com.yapp.growth.domain.entity.Plan
 import com.yapp.growth.presentation.R
 import com.yapp.growth.presentation.component.PlanzCalendar
@@ -117,7 +118,7 @@ fun HomeScreen(
         modifier = Modifier.fillMaxSize(),
     ) { padding ->
         when (viewState.loadState) {
-            HomeContract.LoadState.Loading -> {
+            LoadState.LOADING -> {
                 Box(modifier = Modifier.fillMaxSize()) {
                     PlanzLoading()
                 }
@@ -132,7 +133,7 @@ fun HomeScreen(
                     Spacer(modifier = Modifier.height(3.dp))
                     when (viewState.loginState) {
                         HomeContract.LoginState.LOGIN -> HomeTodayPlan(
-                            isError = viewState.loadState == HomeContract.LoadState.Error,
+                            isError = viewState.loadState == LoadState.ERROR,
                             expanded = viewState.isTodayPlanExpanded,
                             todayPlans = viewState.todayPlans,
                             planCount = viewState.todayPlans.size,
@@ -145,7 +146,7 @@ fun HomeScreen(
                     }
                     Spacer(modifier = Modifier.height(16.dp))
                     HomeMonthlyPlan(
-                        isError = viewState.loadState == HomeContract.LoadState.Error,
+                        isError = viewState.loadState == LoadState.ERROR,
                         expanded = viewState.isMonthlyPlanExpanded,
                         monthlyPlans = viewState.monthlyPlans,
                         mode = viewState.monthlyPlanMode,

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.prolificinteractive.materialcalendarview.CalendarDay
 import com.yapp.growth.LoginSdk
 import com.yapp.growth.base.BaseViewModel
+import com.yapp.growth.base.LoadState
 import com.yapp.growth.domain.onError
 import com.yapp.growth.domain.onSuccess
 import com.yapp.growth.domain.runCatching
@@ -37,7 +38,7 @@ class HomeViewModel @Inject constructor(
 ) {
 
     init {
-        updateState { copy(loadState = HomeContract.LoadState.Loading) }
+        updateState { copy(loadState = LoadState.LOADING) }
         checkValidLoginToken()
     }
 
@@ -89,7 +90,7 @@ class HomeViewModel @Inject constructor(
                     updateState {
                         copy(
                             loginState = LoginState.NONE,
-                            loadState = HomeContract.LoadState.Success
+                            loadState = LoadState.SUCCESS
                         )
                     }
                 }
@@ -97,7 +98,7 @@ class HomeViewModel @Inject constructor(
                 updateState {
                     copy(
                         loginState = LoginState.NONE,
-                        loadState = HomeContract.LoadState.Error
+                        loadState = LoadState.ERROR
                     )
                 }
             }
@@ -113,7 +114,7 @@ class HomeViewModel @Inject constructor(
                     .onSuccess {
                         updateState {
                             copy(
-                                loadState = HomeContract.LoadState.Success,
+                                loadState = LoadState.SUCCESS,
                                 userName = it.userName
                             )
                         }
@@ -121,14 +122,14 @@ class HomeViewModel @Inject constructor(
                     .onError {
                         updateState {
                             copy(
-                                loadState = HomeContract.LoadState.Error
+                                loadState = LoadState.ERROR
                             )
                         }
                     }
             } else {
                 updateState {
                     copy(
-                        loadState = HomeContract.LoadState.Success,
+                        loadState = LoadState.SUCCESS,
                         userName = cacheInfo.userName
                     )
                 }
@@ -149,7 +150,7 @@ class HomeViewModel @Inject constructor(
                     }
                     updateState {
                         copy(
-                            loadState = HomeContract.LoadState.Success,
+                            loadState = LoadState.SUCCESS,
                             allPlans = plans,
                             monthlyPlans = monthlyPlans,
                             todayPlans = todayPlans
@@ -157,7 +158,7 @@ class HomeViewModel @Inject constructor(
                     }
                 }
                 .onError {
-                    updateState { copy(loadState = HomeContract.LoadState.Error) }
+                    updateState { copy(loadState = LoadState.ERROR) }
                 }
         }
     }

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageContract.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageContract.kt
@@ -1,12 +1,13 @@
 package com.yapp.growth.presentation.ui.main.myPage
 
+import com.yapp.growth.base.LoadState
 import com.yapp.growth.base.ViewEvent
 import com.yapp.growth.base.ViewSideEffect
 import com.yapp.growth.base.ViewState
 
 class MyPageContract {
     data class MyPageViewState(
-        val loadState: LoadState = LoadState.Success,
+        val loadState: LoadState = LoadState.SUCCESS,
         val loginState: LoginState = LoginState.NONE,
         val userName: String = "",
         val isDialogVisible: Boolean = false,
@@ -29,10 +30,6 @@ class MyPageContract {
         object OnBackButtonClicked : MyPageEvent()
         object OnNegativeButtonClicked : MyPageEvent()
         object OnPositiveButtonClicked : MyPageEvent()
-    }
-
-    enum class LoadState {
-        Loading, Success, Error
     }
 
     enum class LoginState {

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.yapp.growth.base.LoadState
 import com.yapp.growth.presentation.R
 import com.yapp.growth.presentation.component.PlanzBackAppBar
 import com.yapp.growth.presentation.component.PlanzDialog
@@ -96,7 +97,7 @@ fun MyPageScreen(
     }
 
     when (viewState.loadState) {
-        MyPageContract.LoadState.Success -> {
+        LoadState.SUCCESS -> {
             Scaffold(
                 topBar = {
                     PlanzBackAppBar(
@@ -146,12 +147,12 @@ fun MyPageScreen(
                 )
             }
         }
-        MyPageContract.LoadState.Loading -> {
+        LoadState.LOADING -> {
             Surface(modifier = Modifier.fillMaxSize()) {
                 PlanzLoading()
             }
         }
-        MyPageContract.LoadState.Error -> {
+        LoadState.ERROR -> {
             Surface(modifier = Modifier.fillMaxSize()) {
                 PlanzError()
             }

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageViewModel.kt
@@ -3,6 +3,7 @@ package com.yapp.growth.presentation.ui.main.myPage
 import androidx.lifecycle.viewModelScope
 import com.yapp.growth.LoginSdk
 import com.yapp.growth.base.BaseViewModel
+import com.yapp.growth.base.LoadState
 import com.yapp.growth.domain.onError
 import com.yapp.growth.domain.onSuccess
 import com.yapp.growth.domain.runCatching
@@ -16,7 +17,6 @@ import com.yapp.growth.presentation.ui.main.myPage.MyPageContract.MyPageViewStat
 import com.yapp.growth.presentation.util.ResourceProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -28,7 +28,7 @@ class MyPageViewModel @Inject constructor(
 ) : BaseViewModel<MyPageViewState, MyPageSideEffect, MyPageEvent>(MyPageViewState()) {
 
     init {
-        updateState { copy(loadState = MyPageContract.LoadState.Loading) }
+        updateState { copy(loadState = LoadState.LOADING) }
         checkValidLoginToken()
     }
     
@@ -76,7 +76,7 @@ class MyPageViewModel @Inject constructor(
                     updateState {
                         copy(
                             loginState = LoginState.NONE,
-                            loadState = MyPageContract.LoadState.Success
+                            loadState = LoadState.SUCCESS
                         )
                     }
                 }
@@ -84,7 +84,7 @@ class MyPageViewModel @Inject constructor(
                 updateState {
                     copy(
                         loginState = LoginState.NONE,
-                        loadState = MyPageContract.LoadState.Error
+                        loadState = LoadState.ERROR
                     )
                 }
             }
@@ -130,7 +130,7 @@ class MyPageViewModel @Inject constructor(
                     .onSuccess {
                         updateState {
                             copy(
-                                loadState = MyPageContract.LoadState.Success,
+                                loadState = LoadState.SUCCESS,
                                 userName = it.userName
                             )
                         }
@@ -138,14 +138,14 @@ class MyPageViewModel @Inject constructor(
                     .onError {
                         updateState {
                             copy(
-                                loadState = MyPageContract.LoadState.Error
+                                loadState = LoadState.ERROR,
                             )
                         }
                     }
             } else {
                 updateState {
                     copy(
-                        loadState = MyPageContract.LoadState.Success,
+                        loadState = LoadState.SUCCESS,
                         userName = cacheInfo.userName
                     )
                 }

--- a/presentation/src/main/java/com/yapp/growth/presentation/util/Extends.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/util/Extends.kt
@@ -5,19 +5,18 @@ import java.text.SimpleDateFormat
 import java.util.*
 
 internal val PARSE_DATE_FORMAT = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.KOREA)
-internal val FULL_DATE_FORMAT = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.KOREA)
 internal val DATE_FORMAT = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA)
 
 fun CalendarDay.toFormatDate(): String {
     return DATE_FORMAT.format(this.date)
 }
 
-fun Date.toFormatDate(): String {
-    return DATE_FORMAT.format(this)
-}
-
 fun CalendarDay.toParseFormatDate(): String {
     return PARSE_DATE_FORMAT.format(this.date)
+}
+
+fun Date.toFormatDate(): String {
+    return DATE_FORMAT.format(this)
 }
 
 fun Date.toHour(): String {
@@ -30,6 +29,11 @@ fun Date.toHourAndMinute(): String {
 
 fun Date.toCalculateDiffDay(other: Date): Long {
     return (other.time - this.time) / (60 * 60 * 24 * 1000)
+}
+
+fun String.toDayAndHour(): String {
+    val dateTimeFormat = PARSE_DATE_FORMAT.parse(this) as Date
+    return SimpleDateFormat("M월 d일 aa h시", Locale.KOREA).format(dateTimeFormat)
 }
 
 fun String.toDate(): Date {


### PR DESCRIPTION
## ISSUE
- resolved #148 

<br>

## 작업 내용
- `LoadState`에 따라 약속 상세보기 화면의 표현이 달라지도록 설정
- 홈, 마이페이지가 `base`의 `LoadState`를 사용하도록 변경

## Check List
- [x] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [x] CI/CD 통과 여부
- [ ] 1명 이상의 Approve 확인 후 Merge
- [x] 관련 이슈 연결
