### PR TITLE
[ISSUE-143] 약속 관리 화면에서 로딩 중 엠티 뷰가 보여지는 문제를 수정합니다

### DIFF
--- a/presentation/src/main/java/com/yapp/growth/presentation/component/PlanzSnackBar.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/component/PlanzSnackBar.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import com.yapp.growth.presentation.R
 import com.yapp.growth.presentation.theme.Gray900
-import com.yapp.growth.presentation.theme.MainPurple900
+import com.yapp.growth.presentation.theme.MainPurple700
 import com.yapp.growth.presentation.theme.PlanzTypography
 import com.yapp.growth.presentation.theme.SubCoral
 
@@ -34,7 +34,7 @@ fun PlanzSnackBar(
             modifier = Modifier.padding(vertical = 12.dp),
             text = message,
             style = PlanzTypography.caption,
-            color = MainPurple900
+            color = MainPurple700
         )
     }
 }

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzScreen.kt
@@ -51,11 +51,11 @@ import com.yapp.growth.presentation.theme.Pretendard
 import com.yapp.growth.presentation.ui.main.detail.DetailPlanScreen
 import com.yapp.growth.presentation.ui.main.home.HomeScreen
 import com.yapp.growth.presentation.ui.main.manage.ManageScreen
-import com.yapp.growth.presentation.ui.main.manage.confirm.FixPlanScreen
-import com.yapp.growth.presentation.ui.main.manage.monitor.MonitorPlanScreen
-import com.yapp.growth.presentation.ui.main.manage.respond.RespondPlanScreen
-import com.yapp.growth.presentation.ui.main.manage.respond.result.RespondPlanCompleteScreen
-import com.yapp.growth.presentation.ui.main.manage.respond.result.RespondPlanRejectScreen
+import com.yapp.growth.presentation.ui.main.confirm.FixPlanScreen
+import com.yapp.growth.presentation.ui.main.monitor.MonitorPlanScreen
+import com.yapp.growth.presentation.ui.main.respond.RespondPlanScreen
+import com.yapp.growth.presentation.ui.main.respond.result.RespondPlanCompleteScreen
+import com.yapp.growth.presentation.ui.main.respond.result.RespondPlanRejectScreen
 import com.yapp.growth.presentation.ui.main.myPage.MyPageScreen
 import com.yapp.growth.presentation.ui.main.privacyPolicy.PrivacyPolicyScreen
 import com.yapp.growth.presentation.ui.main.sample.SampleScreen

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/confirm/FixPlanContract.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/confirm/FixPlanContract.kt
@@ -1,4 +1,4 @@
-package com.yapp.growth.presentation.ui.main.manage.confirm
+package com.yapp.growth.presentation.ui.main.confirm
 
 import com.yapp.growth.base.ViewEvent
 import com.yapp.growth.base.ViewSideEffect

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/confirm/FixPlanViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/confirm/FixPlanViewModel.kt
@@ -1,4 +1,4 @@
-package com.yapp.growth.presentation.ui.main.manage.confirm
+package com.yapp.growth.presentation.ui.main.confirm
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
@@ -11,7 +11,7 @@ import com.yapp.growth.domain.onError
 import com.yapp.growth.domain.onSuccess
 import com.yapp.growth.domain.usecase.GetRespondUsersUseCase
 import com.yapp.growth.domain.usecase.SendFixPlanUseCase
-import com.yapp.growth.presentation.ui.main.manage.confirm.FixPlanContract.*
+import com.yapp.growth.presentation.ui.main.confirm.FixPlanContract.*
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/manage/ManageContract.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/manage/ManageContract.kt
@@ -1,5 +1,6 @@
 package com.yapp.growth.presentation.ui.main.manage
 
+import com.yapp.growth.base.LoadState
 import com.yapp.growth.base.ViewEvent
 import com.yapp.growth.base.ViewSideEffect
 import com.yapp.growth.base.ViewState
@@ -7,6 +8,8 @@ import com.yapp.growth.domain.entity.Plan
 
 class ManageContract {
     data class ManageViewState(
+        val waitingPlansLoadState: LoadState = LoadState.SUCCESS,
+        val fixedPlansLoadState: LoadState = LoadState.SUCCESS,
         val waitingPlans: List<Plan.WaitingPlan> = emptyList(),
         val fixedPlans: List<Plan.FixedPlan> = emptyList(),
     ) : ViewState
@@ -21,6 +24,7 @@ class ManageContract {
     }
 
     sealed class ManageEvent : ViewEvent {
+        object InitManageScreen : ManageEvent()
         object OnClickCreateButton : ManageEvent()
         data class OnClickWaitingPlan(val planId: Int) : ManageEvent()
         data class OnClickFixedPlan(val planId: Int) : ManageEvent()

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/manage/ManageScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/manage/ManageScreen.kt
@@ -29,6 +29,7 @@ import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.PagerState
 import com.google.accompanist.pager.rememberPagerState
+import com.yapp.growth.base.LoadState
 import com.yapp.growth.domain.entity.Category
 import com.yapp.growth.domain.entity.Plan
 import com.yapp.growth.presentation.R
@@ -78,6 +79,8 @@ fun ManageScreen(
             )
 
             ManagePager(
+                waitingPlansLoadState = viewState.waitingPlansLoadState,
+                fixedPlansLoadState = viewState.fixedPlansLoadState,
                 pagerState = pagerState,
                 waitingPlans = viewState.waitingPlans,
                 fixedPlans = viewState.fixedPlans,
@@ -115,6 +118,10 @@ fun ManageScreen(
                 }
             }
         }
+    }
+
+    LaunchedEffect(key1 = true) {
+        viewModel.setEvent(ManageEvent.InitManageScreen)
     }
 }
 
@@ -164,6 +171,8 @@ fun ManageTabRow(
 @OptIn(ExperimentalPagerApi::class)
 @Composable
 fun ManagePager(
+    waitingPlansLoadState: LoadState,
+    fixedPlansLoadState: LoadState,
     pagerState: PagerState,
     waitingPlans: List<Plan.WaitingPlan>,
     fixedPlans: List<Plan.FixedPlan>,
@@ -177,24 +186,43 @@ fun ManagePager(
     ) { tabIndex ->
         when (tabIndex) {
             ManageTapMenu.WAITING_PLAN.ordinal -> {
-                if (waitingPlans.isNotEmpty()) {
-                    ManagePlansList(
-                        plans = waitingPlans,
-                        type = ManageTapMenu.WAITING_PLAN,
-                        onItemClick = onWaitingItemClick
-                    )
-                } else ManageEmptyView(onCreateButtonClick = onCreateButtonClick)
+                ManagePagerContent(
+                    loadState = waitingPlansLoadState,
+                    plans = waitingPlans,
+                    type = ManageTapMenu.WAITING_PLAN,
+                    onItemClick = onWaitingItemClick,
+                    onCreateButtonClick = onCreateButtonClick
+                )
             }
             ManageTapMenu.FIXED_PLAN.ordinal -> {
-                if (fixedPlans.isNotEmpty()) {
-                    ManagePlansList(
-                        plans = fixedPlans,
-                        type = ManageTapMenu.FIXED_PLAN,
-                        onItemClick = onFixedItemClick
-                    )
-                } else ManageEmptyView(onCreateButtonClick = onCreateButtonClick)
+                ManagePagerContent(
+                    loadState = fixedPlansLoadState,
+                    plans = fixedPlans,
+                    type = ManageTapMenu.FIXED_PLAN,
+                    onItemClick = onFixedItemClick,
+                    onCreateButtonClick = onCreateButtonClick
+                )
             }
         }
+    }
+}
+
+@Composable
+fun ManagePagerContent(
+    loadState: LoadState,
+    plans: List<Plan>,
+    type: ManageTapMenu,
+    onItemClick: (Int) -> Unit,
+    onCreateButtonClick: () -> Unit,
+) {
+    when (loadState) {
+        LoadState.LOADING -> {}
+        LoadState.SUCCESS -> {
+            if (plans.isNotEmpty()) {
+                ManagePlansList(plans = plans, type = type, onItemClick = onItemClick)
+            } else ManageEmptyView(onCreateButtonClick = onCreateButtonClick)
+        }
+        LoadState.ERROR -> {}
     }
 }
 

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/manage/ManageViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/manage/ManageViewModel.kt
@@ -2,7 +2,9 @@ package com.yapp.growth.presentation.ui.main.manage
 
 import androidx.lifecycle.viewModelScope
 import com.yapp.growth.base.BaseViewModel
-import com.yapp.growth.domain.NetworkResult
+import com.yapp.growth.base.LoadState
+import com.yapp.growth.domain.onError
+import com.yapp.growth.domain.onSuccess
 import com.yapp.growth.domain.usecase.GetFixedPlansUseCase
 import com.yapp.growth.domain.usecase.GetWaitingPlansUseCase
 import com.yapp.growth.presentation.ui.main.manage.ManageContract.*
@@ -18,20 +20,23 @@ class ManageViewModel @Inject constructor(
 ) : BaseViewModel<ManageViewState, ManageSideEffect, ManageEvent>(
     ManageViewState()
 ) {
-    init {
-        getWaitingPlans()
-        getFixedPlans()
-    }
-
     override fun handleEvents(event: ManageEvent) {
         when (event) {
+            is ManageEvent.InitManageScreen -> {
+                getWaitingPlans()
+                getFixedPlans()
+            }
             is ManageEvent.OnClickCreateButton -> sendEffect({ ManageSideEffect.NavigateToCreateScreen })
             is ManageEvent.OnClickWaitingPlan -> {
                 val selectedPlan =
                     viewState.value.waitingPlans.firstOrNull { it.id == event.planId }
                 selectedPlan?.let { waitingPlan ->
-                    if (waitingPlan.isLeader) sendEffect({ ManageSideEffect.NavigateToFixPlanScreen(event.planId) })
-                    else if (waitingPlan.isAlreadyReplied) sendEffect({ ManageSideEffect.NavigateToMonitorPlanScreen(event.planId) })
+                    if (waitingPlan.isLeader) sendEffect({
+                        ManageSideEffect.NavigateToFixPlanScreen(event.planId)
+                    })
+                    else if (waitingPlan.isAlreadyReplied) sendEffect({
+                        ManageSideEffect.NavigateToMonitorPlanScreen(event.planId)
+                    })
                     else sendEffect({ ManageSideEffect.NavigateToMemberResponseScreen(event.planId) })
                 }
             }
@@ -42,41 +47,23 @@ class ManageViewModel @Inject constructor(
         }
     }
 
-    private fun getWaitingPlans() {
-        viewModelScope.launch {
-            when (val result = getWaitingPlansUseCase()) {
-                is NetworkResult.Success -> {
-                    updateState {
-                        copy(waitingPlans = result.data)
-                    }
-                    Timber.w("waitingPlans = ${result.data}")
-                }
-                is NetworkResult.Error -> {
-                    Timber.w("waitingPlans error = ${result.exception}")
-                }
-                is NetworkResult.Loading -> {
-
-                }
+    private fun getWaitingPlans() = viewModelScope.launch {
+        updateState { copy(waitingPlansLoadState = LoadState.LOADING) }
+        getWaitingPlansUseCase()
+            .onSuccess { waitingPlans ->
+                updateState { copy(waitingPlansLoadState = LoadState.SUCCESS, waitingPlans = waitingPlans) }
+            }.onError {
+                updateState { copy(waitingPlansLoadState = LoadState.ERROR) }
             }
-        }
     }
 
-    private fun getFixedPlans() {
-        viewModelScope.launch {
-            when (val result = getFixedPlansUseCase()) {
-                is NetworkResult.Success -> {
-                    updateState {
-                        copy(fixedPlans = result.data)
-                    }
-                    Timber.w("fixedPlans = ${result.data}")
-                }
-                is NetworkResult.Error -> {
-                    Timber.w("fixedPlans error = ${result.exception}")
-                }
-                is NetworkResult.Loading -> {
-
-                }
+    private fun getFixedPlans() = viewModelScope.launch {
+        updateState { copy(fixedPlansLoadState = LoadState.LOADING) }
+        getFixedPlansUseCase()
+            .onSuccess { fixedPlans ->
+                updateState { copy(fixedPlansLoadState = LoadState.SUCCESS, fixedPlans = fixedPlans) }
+            }.onError {
+                updateState { copy(fixedPlansLoadState = LoadState.ERROR) }
             }
-        }
     }
 }

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/monitor/MonitorPlanContract.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/monitor/MonitorPlanContract.kt
@@ -1,4 +1,4 @@
-package com.yapp.growth.presentation.ui.main.manage.monitor
+package com.yapp.growth.presentation.ui.main.monitor
 
 import com.yapp.growth.base.ViewEvent
 import com.yapp.growth.base.ViewSideEffect

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/monitor/MonitorPlanViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/monitor/MonitorPlanViewModel.kt
@@ -1,4 +1,4 @@
-package com.yapp.growth.presentation.ui.main.manage.monitor
+package com.yapp.growth.presentation.ui.main.monitor
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
@@ -10,9 +10,9 @@ import com.yapp.growth.domain.entity.User
 import com.yapp.growth.domain.onError
 import com.yapp.growth.domain.onSuccess
 import com.yapp.growth.domain.usecase.GetRespondUsersUseCase
-import com.yapp.growth.presentation.ui.main.manage.confirm.FixPlanContract
+import com.yapp.growth.presentation.ui.main.confirm.FixPlanContract
 import dagger.hilt.android.lifecycle.HiltViewModel
-import com.yapp.growth.presentation.ui.main.manage.monitor.MonitorPlanContract.*
+import com.yapp.growth.presentation.ui.main.monitor.MonitorPlanContract.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/respond/RespondPlanContract.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/respond/RespondPlanContract.kt
@@ -1,4 +1,4 @@
-package com.yapp.growth.presentation.ui.main.manage.respond
+package com.yapp.growth.presentation.ui.main.respond
 
 import com.yapp.growth.base.ViewEvent
 import com.yapp.growth.base.ViewSideEffect

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/respond/RespondPlanScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/respond/RespondPlanScreen.kt
@@ -1,4 +1,4 @@
-package com.yapp.growth.presentation.ui.main.manage.respond
+package com.yapp.growth.presentation.ui.main.respond
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -29,8 +29,8 @@ import com.yapp.growth.presentation.theme.Gray100
 import com.yapp.growth.presentation.theme.Gray300
 import com.yapp.growth.presentation.theme.Gray800
 import com.yapp.growth.presentation.theme.PlanzTypography
-import com.yapp.growth.presentation.ui.main.manage.respond.RespondPlanContract.RespondPlanEvent
-import com.yapp.growth.presentation.ui.main.manage.respond.RespondPlanContract.RespondPlanSideEffect
+import com.yapp.growth.presentation.ui.main.respond.RespondPlanContract.RespondPlanEvent
+import com.yapp.growth.presentation.ui.main.respond.RespondPlanContract.RespondPlanSideEffect
 
 @Composable
 fun RespondPlanScreen(

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/respond/RespondPlanViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/respond/RespondPlanViewModel.kt
@@ -1,4 +1,4 @@
-package com.yapp.growth.presentation.ui.main.manage.respond
+package com.yapp.growth.presentation.ui.main.respond
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
@@ -12,7 +12,7 @@ import com.yapp.growth.domain.onSuccess
 import com.yapp.growth.domain.usecase.GetRespondUsersUseCase
 import com.yapp.growth.domain.usecase.SendRejectPlanUseCase
 import com.yapp.growth.domain.usecase.SendRespondPlanUseCase
-import com.yapp.growth.presentation.ui.main.manage.respond.RespondPlanContract.*
+import com.yapp.growth.presentation.ui.main.respond.RespondPlanContract.*
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/respond/result/RespondPlanCompleteScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/respond/result/RespondPlanCompleteScreen.kt
@@ -1,4 +1,4 @@
-package com.yapp.growth.presentation.ui.main.manage.respond.result
+package com.yapp.growth.presentation.ui.main.respond.result
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/respond/result/RespondPlanRejectScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/respond/result/RespondPlanRejectScreen.kt
@@ -1,4 +1,4 @@
-package com.yapp.growth.presentation.ui.main.manage.respond.result
+package com.yapp.growth.presentation.ui.main.respond.result
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*


### PR DESCRIPTION
## ISSUE
- resolved #143 

<br>

## 작업 내용
- waitingPlansLoadState, fixedPlansLoadState를 추가하여 로딩 중에 엠티뷰가 보여지지 않도록 수정
- 스낵바 디자인 변경사항 반영(글자색 수정)
- manage 하위에 있던 confirm, monitor, respond 패키지를 main 하위 패키지로 이동


<br>

## 실행 화면

| Screen Shot | Screen Shot |
| ----------- | ----------- |
|             |             |


<br>

## Check List
- [ ] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [ ] CI/CD 통과 여부
- [ ] 1명 이상의 Approve 확인 후 Merge
- [ ] 관련 이슈 연결
