### PR TITLE
[ISSUE-163] 홈 비로그인 관련 로직 변경

### DIFF
--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzContract.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzContract.kt
@@ -33,7 +33,7 @@ class PlanzContract {
 
     sealed class PlanzEvent : ViewEvent {
         data class OnPlanItemClicked(val planId: Int) : PlanzEvent()
-        object OnNoneLoginBottomNavigationClicked : PlanzEvent()
+        object OnBottomNavigationClickedWhenNotLogin : PlanzEvent()
         object OnBottomSheetExitClicked : PlanzEvent()
         data class ShowBottomSheet(
             val selectionDay: CalendarDay,

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzContract.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzContract.kt
@@ -12,6 +12,7 @@ import com.yapp.growth.presentation.theme.BackgroundColor1
 class PlanzContract {
 
     data class PlanzViewState(
+        val loginState: LoginState = LoginState.NONE,
         val selectDayPlans: List<Plan.FixedPlan> = emptyList(),
         val selectionDay: CalendarDay = CalendarDay.today(),
         val userPlanStatus: UserPlanStatus = UserPlanStatus.UNKNOWN,
@@ -27,10 +28,12 @@ class PlanzContract {
         data class MoveToMonitorPlan(val planId: Long): PlanzSideEffect()
         object MoveToAlreadyConfirmPlan: PlanzSideEffect()
         object MoveToFulledPlan: PlanzSideEffect()
+        object MoveToLogin: PlanzSideEffect()
     }
 
     sealed class PlanzEvent : ViewEvent {
         data class OnPlanItemClicked(val planId: Int) : PlanzEvent()
+        object OnNoneLoginBottomNavigationClicked : PlanzEvent()
         object OnBottomSheetExitClicked : PlanzEvent()
         data class ShowBottomSheet(
             val selectionDay: CalendarDay,
@@ -38,5 +41,9 @@ class PlanzContract {
         ) : PlanzEvent()
         data class GetUserPlanStatus(val planId: Long): PlanzEvent()
         data class ChangeStatusBarColor(val color: Color): PlanzEvent()
+    }
+
+    enum class LoginState {
+        NONE, LOGIN
     }
 }

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzScreen.kt
@@ -47,6 +47,7 @@ import com.yapp.growth.presentation.component.PlanzModalBottomSheetLayout
 import com.yapp.growth.presentation.firebase.PLAN_ID_KEY_NAME
 import com.yapp.growth.presentation.firebase.SchemeType
 import com.yapp.growth.presentation.theme.*
+import com.yapp.growth.presentation.ui.login.LoginActivity
 import com.yapp.growth.presentation.ui.main.confirm.FixPlanScreen
 import com.yapp.growth.presentation.ui.main.detail.DetailPlanScreen
 import com.yapp.growth.presentation.ui.main.home.DayPlanItem
@@ -117,9 +118,11 @@ fun PlanzScreen(
                         currentDestination = currentDestination,
                         navigateToScreen = { navigationItem ->
                             navigateBottomNavigationScreen(
-                                navController,
-                                navigationItem,
-                                intentToCreatePlan
+                                navController = navController,
+                                navigationItem = navigationItem,
+                                loginState = viewState.loginState,
+                                onNoneLoginBottomNavigationClicked = { viewModel.setEvent(PlanzContract.PlanzEvent.OnNoneLoginBottomNavigationClicked) },
+                                moveToCreatePlan = intentToCreatePlan
                             )
                         }
                     )
@@ -324,6 +327,10 @@ fun PlanzScreen(
                 PlanzContract.PlanzSideEffect.MoveToFulledPlan -> {
                     navController.navigate(PlanzScreenRoute.FULLED_PLAN.route)
                 }
+                is PlanzContract.PlanzSideEffect.MoveToLogin -> {
+                    LoginActivity.startActivity(context, null)
+                    context.finish()
+                }
                 is PlanzContract.PlanzSideEffect.MoveToConfirmPlan -> {
                     navController.navigate(PlanzScreenRoute.CONFIRM_PLAN.route.plus("/${effect.planId}"))
                 }
@@ -484,8 +491,15 @@ fun PlanzPlanList(
 fun navigateBottomNavigationScreen(
     navController: NavHostController,
     navigationItem: BottomNavigationItem,
+    loginState: PlanzContract.LoginState,
+    onNoneLoginBottomNavigationClicked: () -> Unit,
     moveToCreatePlan: () -> Unit,
 ) {
+    if(loginState == PlanzContract.LoginState.NONE) {
+        onNoneLoginBottomNavigationClicked()
+        return
+    }
+
     if (navigationItem == BottomNavigationItem.CREATE_PLAN) {
         moveToCreatePlan()
     } else {

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzScreen.kt
@@ -4,16 +4,38 @@ import android.app.Activity
 import android.net.Uri
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.*
-import androidx.compose.runtime.*
+import androidx.compose.material.BottomNavigation
+import androidx.compose.material.BottomNavigationItem
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.FabPosition
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -46,7 +68,12 @@ import com.yapp.growth.presentation.R
 import com.yapp.growth.presentation.component.PlanzModalBottomSheetLayout
 import com.yapp.growth.presentation.firebase.PLAN_ID_KEY_NAME
 import com.yapp.growth.presentation.firebase.SchemeType
-import com.yapp.growth.presentation.theme.*
+import com.yapp.growth.presentation.theme.BackgroundColor1
+import com.yapp.growth.presentation.theme.Gray500
+import com.yapp.growth.presentation.theme.Gray900
+import com.yapp.growth.presentation.theme.MainPurple900
+import com.yapp.growth.presentation.theme.PlanzTypography
+import com.yapp.growth.presentation.theme.Pretendard
 import com.yapp.growth.presentation.ui.login.LoginActivity
 import com.yapp.growth.presentation.ui.main.confirm.FixPlanScreen
 import com.yapp.growth.presentation.ui.main.detail.DetailPlanScreen
@@ -121,7 +148,11 @@ fun PlanzScreen(
                                 navController = navController,
                                 navigationItem = navigationItem,
                                 loginState = viewState.loginState,
-                                onNoneLoginBottomNavigationClicked = { viewModel.setEvent(PlanzContract.PlanzEvent.OnNoneLoginBottomNavigationClicked) },
+                                onNoneLoginBottomNavigationClicked = {
+                                    viewModel.setEvent(
+                                        PlanzContract.PlanzEvent.OnNoneLoginBottomNavigationClicked
+                                    )
+                                },
                                 moveToCreatePlan = intentToCreatePlan
                             )
                         }
@@ -130,9 +161,16 @@ fun PlanzScreen(
             },
             floatingActionButton = {
                 if (bottomBarState) {
-                    CreatePlanFAB(modifier = Modifier.padding(top = 12.dp)) {
-                        intentToCreatePlan()
-                    }
+                    CreatePlanFAB(
+                        modifier = Modifier.padding(top = 12.dp),
+                        navigateToManageScreen = { intentToCreatePlan() },
+                        loginState = viewState.loginState,
+                        onNoneLoginBottomNavigationClicked = {
+                            viewModel.setEvent(
+                                PlanzContract.PlanzEvent.OnNoneLoginBottomNavigationClicked
+                            )
+                        },
+                    )
                 }
             },
             isFloatingActionButtonDocked = true,
@@ -155,8 +193,12 @@ fun PlanzScreen(
                             )
                         },
                         showBottomSheet = { calendarDay, fixedPlans ->
-                            viewModel.setEvent(PlanzContract.PlanzEvent.ShowBottomSheet(calendarDay,
-                                fixedPlans))
+                            viewModel.setEvent(
+                                PlanzContract.PlanzEvent.ShowBottomSheet(
+                                    calendarDay,
+                                    fixedPlans
+                                )
+                            )
                         }
                     )
                 }
@@ -320,7 +362,7 @@ fun PlanzScreen(
 
     LaunchedEffect(key1 = viewModel.effect) {
         viewModel.effect.collect { effect ->
-            when(effect) {
+            when (effect) {
                 PlanzContract.PlanzSideEffect.MoveToAlreadyConfirmPlan -> {
                     navController.navigate(PlanzScreenRoute.ALREADY_CONFIRM_PLAN.route)
                 }
@@ -409,12 +451,14 @@ fun PlanzBottomNavigation(
 fun CreatePlanFAB(
     modifier: Modifier = Modifier,
     navigateToManageScreen: () -> Unit,
+    loginState: PlanzContract.LoginState,
+    onNoneLoginBottomNavigationClicked: () -> Unit,
 ) {
     Column(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        IconButton(onClick = { navigateToManageScreen() }) {
+        IconButton(onClick = if (loginState == PlanzContract.LoginState.NONE) onNoneLoginBottomNavigationClicked else navigateToManageScreen) {
             Icon(
                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_fab_create),
                 contentDescription = null,
@@ -495,7 +539,7 @@ fun navigateBottomNavigationScreen(
     onNoneLoginBottomNavigationClicked: () -> Unit,
     moveToCreatePlan: () -> Unit,
 ) {
-    if(loginState == PlanzContract.LoginState.NONE) {
+    if (loginState == PlanzContract.LoginState.NONE) {
         onNoneLoginBottomNavigationClicked()
         return
     }

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzScreen.kt
@@ -150,7 +150,7 @@ fun PlanzScreen(
                                 loginState = viewState.loginState,
                                 onNoneLoginBottomNavigationClicked = {
                                     viewModel.setEvent(
-                                        PlanzContract.PlanzEvent.OnNoneLoginBottomNavigationClicked
+                                        PlanzContract.PlanzEvent.OnBottomNavigationClickedWhenNotLogin
                                     )
                                 },
                                 moveToCreatePlan = intentToCreatePlan
@@ -167,7 +167,7 @@ fun PlanzScreen(
                         loginState = viewState.loginState,
                         onNoneLoginBottomNavigationClicked = {
                             viewModel.setEvent(
-                                PlanzContract.PlanzEvent.OnNoneLoginBottomNavigationClicked
+                                PlanzContract.PlanzEvent.OnBottomNavigationClickedWhenNotLogin
                             )
                         },
                     )

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzViewModel.kt
@@ -68,7 +68,7 @@ class PlanzViewModel @Inject constructor(
             is PlanzEvent.OnPlanItemClicked -> {
                 sendEffect({ PlanzSideEffect.NavigateDetailPlanScreen(event.planId) })
             }
-            is PlanzEvent.OnNoneLoginBottomNavigationClicked -> {
+            is PlanzEvent.OnBottomNavigationClickedWhenNotLogin -> {
                 sendEffect({ PlanzSideEffect.MoveToLogin })
             }
             is PlanzEvent.OnBottomSheetExitClicked -> {

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeScreen.kt
@@ -304,13 +304,14 @@ fun HomeInduceLogin(
                 cornersRadius = 12.dp,
                 shadowBlurRadius = 10.dp,
                 offsetY = 7.dp
-            ),
+            )
     ) {
         Box(
             modifier = Modifier
                 .height(60.dp)
                 .fillMaxWidth()
-                .background(brush = MainGradient),
+                .background(brush = MainGradient)
+                .clickable { OnInduceLoginClick() },
             contentAlignment = Alignment.Center,
         ) {
             Row(
@@ -325,16 +326,12 @@ fun HomeInduceLogin(
                     color = Color.White,
                     style = MaterialTheme.typography.subtitle2,
                 )
-                IconButton(
+                Icon(
                     modifier = Modifier.size(6.dp, 12.dp),
-                    onClick = { OnInduceLoginClick() },
-                ) {
-                    Icon(
-                        tint = Color.Unspecified,
-                        imageVector = ImageVector.vectorResource(R.drawable.ic_transparent_arrow_right),
-                        contentDescription = null,
-                    )
-                }
+                    tint = Color.Unspecified,
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_transparent_arrow_right),
+                    contentDescription = null,
+                )
             }
         }
     }

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeViewModel.kt
@@ -48,6 +48,10 @@ class HomeViewModel @Inject constructor(
         initialValue = _currentDate.value
     )
 
+    init {
+        updateState { copy(loadState = LoadState.LOADING) }
+    }
+
     override fun handleEvents(event: HomeEvent) {
         when (event) {
             is HomeEvent.InitHomeScreen -> {

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeViewModel.kt
@@ -10,11 +10,13 @@ import com.yapp.growth.domain.onSuccess
 import com.yapp.growth.domain.runCatching
 import com.yapp.growth.domain.usecase.GetFixedPlansUseCase
 import com.yapp.growth.domain.usecase.GetUserInfoUseCase
+import com.yapp.growth.presentation.R
 import com.yapp.growth.presentation.ui.main.home.HomeContract.HomeEvent
 import com.yapp.growth.presentation.ui.main.home.HomeContract.HomeSideEffect
 import com.yapp.growth.presentation.ui.main.home.HomeContract.HomeViewState
 import com.yapp.growth.presentation.ui.main.home.HomeContract.LoginState
 import com.yapp.growth.presentation.ui.main.home.HomeContract.MonthlyPlanModeState
+import com.yapp.growth.presentation.util.ResourceProvider
 import com.yapp.growth.presentation.util.toDate
 import com.yapp.growth.presentation.util.toFormatDate
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -32,6 +34,7 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     private val getFixedPlansUseCase: GetFixedPlansUseCase,
     private val getUserInfoUseCase: GetUserInfoUseCase,
+    private val resourcesProvider: ResourceProvider,
     private val kakaoLoginSdk: LoginSdk
 ) : BaseViewModel<HomeViewState, HomeSideEffect, HomeEvent>(
     HomeViewState()
@@ -88,6 +91,7 @@ class HomeViewModel @Inject constructor(
                     updateState {
                         copy(
                             loginState = LoginState.NONE,
+                            userName = resourcesProvider.getString(R.string.planz_title),
                             loadState = LoadState.SUCCESS
                         )
                     }


### PR DESCRIPTION
## ISSUE
- resolved #161 
- resolved #162 
- resolved #163 

<br>

## 작업 내용
- 비로그인 관련 로직 변경
  - 비로그인 시 유저 네임을 플랜즈로 변경
  - 비로그인 시 바텀 네비게이션을 클릭하면 로그인 화면으로 이동하도록 설정
  - 비로그인 시 로그인 유도 박스의 클릭 범위 변경

## Check List
- [x] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [x] CI/CD 통과 여부
- [ ] 1명 이상의 Approve 확인 후 Merge
- [x] 관련 이슈 연결
