### PR TITLE
[ISSUE-155] 캘린더 바텀시트 관련 로직 변경

### DIFF
--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzScreen.kt
@@ -511,7 +511,7 @@ fun PlanzBottomSheetContent(
         } else {
             Spacer(modifier = Modifier.height(70.dp))
             Text(
-                text = "오늘의 약속이 없습니다.",
+                text = stringResource(id = R.string.planz_has_not_plan),
                 style = PlanzTypography.body1,
                 color = Gray500,
                 modifier = Modifier.align(Alignment.CenterHorizontally)

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/PlanzScreen.kt
@@ -502,11 +502,23 @@ fun PlanzBottomSheetContent(
                     .clickable { onExitClick() },
             )
         }
-        Spacer(modifier = Modifier.height(24.dp))
-        PlanzPlanList(
-            dayPlans = selectDayPlans,
-            onPlanItemClick = onPlanItemClick
-        )
+        if(selectDayPlans.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(24.dp))
+            PlanzPlanList(
+                dayPlans = selectDayPlans,
+                onPlanItemClick = onPlanItemClick
+            )
+        } else {
+            Spacer(modifier = Modifier.height(70.dp))
+            Text(
+                text = "오늘의 약속이 없습니다.",
+                style = PlanzTypography.body1,
+                color = Gray500,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            )
+            Spacer(modifier = Modifier.height(70.dp))
+        }
+
     }
 }
 

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeScreen.kt
@@ -477,8 +477,7 @@ fun HomeCalendar(
         currentDate = currentDate,
         selectMode = PlanzCalendarSelectMode.SINGLE,
         onDateSelectedListener = { widget, date, selected ->
-            if (monthlyPlanDates.containsKey(date))
-                onDateClick(date)
+            onDateClick(date)
         },
         monthlyDates = monthlyPlanDates
     )

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeScreen.kt
@@ -477,7 +477,7 @@ fun HomeCalendar(
         currentDate = currentDate,
         selectMode = PlanzCalendarSelectMode.SINGLE,
         onDateSelectedListener = { widget, date, selected ->
-            if (date != CalendarDay.today() && monthlyPlanDates.containsKey(date))
+            if (monthlyPlanDates.containsKey(date))
                 onDateClick(date)
         },
         monthlyDates = monthlyPlanDates

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
 
     <string name="planz_error_text_01">문제가 발생했습니다.</string>
     <string name="planz_error_text_02">다시 시도해주세요.</string>
+    <string name="planz_has_not_plan">오늘의 약속이 없습니다.</string>
 
     <string name="navigation_home_text">메인 홈</string>
     <string name="navigation_create_plan_text">약속잡기</string>


### PR DESCRIPTION
## ISSUE
- resolved #155 
- resolved #165 

<br>

## 작업 내용
- 바텀시트 관련 로직 변경
  - 오늘 날짜를 클릭하더라도 바텀시트를 표현하도록 수정
  - 약속이 없는 날을 클릭했을 때 바텀시트에서 약속이 없음을 안내하도록 수정


<br>

## 실행 화면

| Screen Shot | Screen Shot |
| ----------- | ----------- |
|  ![Screenshot_1659358772](https://user-images.githubusercontent.com/85336456/182153305-a28fdafd-3fb7-4651-82de-179e161ca779.png)           |          ![Screenshot_1659358769](https://user-images.githubusercontent.com/85336456/182153316-98b82c20-fae0-4a50-b4cf-c4087ed624c6.png)   |




<br>

## Check List
- [x] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [x] CI/CD 통과 여부
- [ ] 1명 이상의 Approve 확인 후 Merge
- [x] 관련 이슈 연결
