### PR TITLE
[ISSUE-177] 대기중인 약속 목록 리스트에 파티장 정보 노출

### DIFF
--- a/data/src/main/java/com/yapp/growth/data/internal/response/WaitingPlanResponseImpl.kt
+++ b/data/src/main/java/com/yapp/growth/data/internal/response/WaitingPlanResponseImpl.kt
@@ -10,6 +10,8 @@ data class WaitingPlanResponseImpl(
     override val title: String,
     @Json(name = "isOwner")
     override val isLeader: Boolean,
+    @Json(name = "owner")
+    override val leader: UserResponseImpl,
     @Json(name = "minTime")
     override val startTime: String,
     @Json(name = "maxTime")

--- a/data/src/main/java/com/yapp/growth/data/mapper/WaitingPlanMapper.kt
+++ b/data/src/main/java/com/yapp/growth/data/mapper/WaitingPlanMapper.kt
@@ -8,6 +8,7 @@ fun WaitingPlanResponse.toWaitingPlan(): Plan.WaitingPlan {
         id = id,
         title = title,
         isLeader = isLeader,
+        leader = leader.userName,
         category = category.toCategory(),
         members = members.map { it.userName },
         startTime = 0, // TODO

--- a/data/src/main/java/com/yapp/growth/data/response/WaitingPlanResponse.kt
+++ b/data/src/main/java/com/yapp/growth/data/response/WaitingPlanResponse.kt
@@ -4,6 +4,7 @@ interface WaitingPlanResponse {
     val id: Int
     val title: String
     val isLeader: Boolean
+    val leader: UserResponse
     val startTime: String
     val endTime: String
     val category: CategoryResponse

--- a/domain/src/main/java/com/yapp/growth/domain/entity/Plan.kt
+++ b/domain/src/main/java/com/yapp/growth/domain/entity/Plan.kt
@@ -12,6 +12,7 @@ sealed class Plan(
         override val id: Int,
         override val title: String,
         override val isLeader: Boolean = false,
+        val leader: String,
         override val category: Category,
         override val members: List<String>,
         override val place: String,

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/manage/ManageScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/manage/ManageScreen.kt
@@ -311,7 +311,9 @@ fun ManagePlansItem(
                             }
                         }
                         ManageTapMenu.WAITING_PLAN -> {
-                            "${plan.members.size}" + stringResource(id = R.string.manage_plan_completed_member_count_text)
+                            (plan as Plan.WaitingPlan).leader +
+                                    " | ${plan.members.size}" +
+                                    stringResource(id = R.string.manage_plan_completed_member_count_text)
                         }
                     },
                     style = PlanzTypography.caption,
@@ -417,6 +419,7 @@ fun WaitingPlanItemPreview() {
             id = 0,
             title = "plan title",
             isLeader = true,
+            leader = "member0",
             category = Category(1, "test", "식사"),
             members = listOf("member1", "member2", "member3", "member4"),
             place = "place",


### PR DESCRIPTION
## ISSUE
- resolved #177 

<br>

## 작업 내용
- 대기중인 약속 목록 리스트에 파티장 정보 노출
  - WaitingPlan 도메인 모델에 파티장 정보 추가


<br>

## 실행 화면

| Screen Shot | Screen Shot |
| ----------- | ----------- |
| <img width="510" alt="스크린샷 2022-08-02 오후 9 27 52" src="https://user-images.githubusercontent.com/42907876/182374473-4d6738b4-11a8-40f6-8c39-aa1cd70b4615.png"> |             |


<br>

## Check List
- [ ] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [ ] CI/CD 통과 여부
- [ ] 1명 이상의 Approve 확인 후 Merge
- [ ] 관련 이슈 연결
