### PR TITLE
[ISSUE-189] 약속 생성 step2 무한 로딩 수정

### DIFF
--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/createPlan/theme/ThemeScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/createPlan/theme/ThemeScreen.kt
@@ -21,6 +21,7 @@ import com.yapp.growth.base.LoadState
 import com.yapp.growth.presentation.R
 import com.yapp.growth.presentation.component.PlanzCreateStepTitle
 import com.yapp.growth.presentation.component.PlanzError
+import com.yapp.growth.presentation.component.PlanzLoading
 import com.yapp.growth.presentation.component.PlanzMainButton
 import com.yapp.growth.presentation.theme.*
 import com.yapp.growth.presentation.ui.createPlan.CreatePlanContract.CreatePlanEvent.DecideCategory
@@ -68,7 +69,7 @@ fun ThemeScreen(
                         }
                     }
                 }
-                LoadState.LOADING -> {}
+                LoadState.LOADING -> PlanzLoading()
                 LoadState.ERROR -> PlanzError(retryVisible = true)
             }
 

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/createPlan/title/TitleScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/createPlan/title/TitleScreen.kt
@@ -14,10 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.yapp.growth.base.LoadState
 import com.yapp.growth.presentation.R
-import com.yapp.growth.presentation.component.PlanzButtonWithBack
-import com.yapp.growth.presentation.component.PlanzCreateStepTitle
-import com.yapp.growth.presentation.component.PlanzError
-import com.yapp.growth.presentation.component.PlanzTextField
+import com.yapp.growth.presentation.component.*
 import com.yapp.growth.presentation.ui.createPlan.CreatePlanContract.CreatePlanEvent.DecidePlace
 import com.yapp.growth.presentation.ui.createPlan.CreatePlanContract.CreatePlanEvent.DecideTitle
 import com.yapp.growth.presentation.ui.createPlan.CreatePlanViewModel
@@ -82,7 +79,7 @@ fun TitleScreen(
                         )
                     }
                 }
-                LoadState.LOADING -> {}
+                LoadState.LOADING -> PlanzLoading()
                 LoadState.ERROR -> PlanzError(retryVisible = true)
             }
 

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/createPlan/title/TitleViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/createPlan/title/TitleViewModel.kt
@@ -31,10 +31,14 @@ class TitleViewModel @Inject constructor(
     }
 
     private fun getSampleTitle(categoryId: Int) = viewModelScope.launch {
-        updateState { copy(loadState = LoadState.LOADING) }
+        updateState { copy(loadState = LoadState.LOADING, isError = true) }
         getSampleTitleUseCase.invoke(categoryId)
             .onSuccess { sampleTitle ->
-                updateState { copy(loadState = LoadState.SUCCESS, sampleTitle = sampleTitle) }
+                updateState { copy(
+                    loadState = LoadState.SUCCESS,
+                    sampleTitle = sampleTitle,
+                    isError = isOverflowed(viewState.value.title, viewState.value.place)
+                ) }
             }
             .onError { updateState { copy(loadState = LoadState.ERROR) } }
     }
@@ -47,7 +51,7 @@ class TitleViewModel @Inject constructor(
             copy(
                 title = title,
                 place = place,
-                isError = isOverflowed(title, place)
+                isError = isOverflowed(title, place) || (loadState != LoadState.SUCCESS)
             )
         }
     }

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/createPlan/title/TitleViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/createPlan/title/TitleViewModel.kt
@@ -34,7 +34,7 @@ class TitleViewModel @Inject constructor(
         updateState { copy(loadState = LoadState.LOADING) }
         getSampleTitleUseCase.invoke(categoryId)
             .onSuccess { sampleTitle ->
-                updateState { copy(loadState = LoadState.LOADING, sampleTitle = sampleTitle) }
+                updateState { copy(loadState = LoadState.SUCCESS, sampleTitle = sampleTitle) }
             }
             .onError { updateState { copy(loadState = LoadState.ERROR) } }
     }


### PR DESCRIPTION
## ISSUE
- resolved #189 

<br>

## 작업 내용
- 약속 생성 step2 무한 로딩 수정
- 약속 생성 step2 로딩 화면 추가
- 약속 생성 step2 로딩/에러 상태 시 다음 버튼 비활성화
- 약속 생성 step1 로딩 화면 추가


<br>

## 실행 화면

| Screen Shot | Screen Shot |
| ----------- | ----------- |
|             |             |


<br>

## Check List
- [ ] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [ ] CI/CD 통과 여부
- [ ] 1명 이상의 Approve 확인 후 Merge
- [ ] 관련 이슈 연결
