### PR TITLE
[ISSUE-222] 로그아웃, 탈퇴 시 캐싱된 유저 데이터를 삭제하도록 수정

### DIFF
--- a/data/src/main/java/com/yapp/growth/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/yapp/growth/data/repository/UserRepositoryImpl.kt
@@ -40,6 +40,7 @@ internal class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun deleteUserInfo(): NetworkResult<Unit> {
+        removeCachedUserInfo()
         return dataSource.deleteUserInfo()
     }
 }

--- a/data/src/main/java/com/yapp/growth/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/yapp/growth/data/repository/UserRepositoryImpl.kt
@@ -39,7 +39,7 @@ internal class UserRepositoryImpl @Inject constructor(
         return dataSource.getUserPlanStatus(planId)
     }
 
-    override suspend fun deleteUserInfo(): NetworkResult<Unit> {
+    override suspend fun removeUserInfo(): NetworkResult<Unit> {
         removeCachedUserInfo()
         return dataSource.deleteUserInfo()
     }

--- a/data/src/main/java/com/yapp/growth/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/yapp/growth/data/repository/UserRepositoryImpl.kt
@@ -21,7 +21,7 @@ internal class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun modifyNickName(nickName: String): NetworkResult<User> {
-        cachedUserInfo = null
+        removeCachedUserInfo()
         return dataSource.modifyNickName(nickName)
     }
 
@@ -31,12 +31,15 @@ internal class UserRepositoryImpl @Inject constructor(
 
     override fun getCachedUserInfo(): User? = cachedUserInfo
 
+    override fun removeCachedUserInfo() {
+        cachedUserInfo = null
+    }
+
     override suspend fun getUserPlanStatus(planId: Long): NetworkResult<UserPlanStatus> {
         return dataSource.getUserPlanStatus(planId)
     }
 
     override suspend fun deleteUserInfo(): NetworkResult<Unit> {
-        cachedUserInfo = null
         return dataSource.deleteUserInfo()
     }
 }

--- a/domain/src/main/java/com/yapp/growth/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/com/yapp/growth/domain/repository/UserRepository.kt
@@ -9,7 +9,9 @@ interface UserRepository {
 
     suspend fun modifyNickName(nickName: String): NetworkResult<User>
     suspend fun getUserInfo(): NetworkResult<User>
+
     fun getCachedUserInfo(): User?
+    fun removeCachedUserInfo()
 
     suspend fun getUserPlanStatus(planId: Long): NetworkResult<UserPlanStatus>
     suspend fun deleteUserInfo(): NetworkResult<Unit>

--- a/domain/src/main/java/com/yapp/growth/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/com/yapp/growth/domain/repository/UserRepository.kt
@@ -14,5 +14,5 @@ interface UserRepository {
     fun removeCachedUserInfo()
 
     suspend fun getUserPlanStatus(planId: Long): NetworkResult<UserPlanStatus>
-    suspend fun deleteUserInfo(): NetworkResult<Unit>
+    suspend fun removeUserInfo(): NetworkResult<Unit>
 }

--- a/domain/src/main/java/com/yapp/growth/domain/usecase/RemoveCachedUserInfoUseCase.kt
+++ b/domain/src/main/java/com/yapp/growth/domain/usecase/RemoveCachedUserInfoUseCase.kt
@@ -1,0 +1,10 @@
+package com.yapp.growth.domain.usecase
+
+import com.yapp.growth.domain.repository.UserRepository
+import javax.inject.Inject
+
+class RemoveCachedUserInfoUseCase @Inject constructor(
+    private val repository: UserRepository
+) {
+    suspend operator fun invoke() = repository.removeCachedUserInfo()
+}

--- a/domain/src/main/java/com/yapp/growth/domain/usecase/RemoveUserInfoUseCase.kt
+++ b/domain/src/main/java/com/yapp/growth/domain/usecase/RemoveUserInfoUseCase.kt
@@ -1,14 +1,13 @@
 package com.yapp.growth.domain.usecase
 
 import com.yapp.growth.domain.NetworkResult
-import com.yapp.growth.domain.entity.User
 import com.yapp.growth.domain.repository.UserRepository
 import javax.inject.Inject
 
-class DeleteUserInfoUseCase @Inject constructor(
+class RemoveUserInfoUseCase @Inject constructor(
     private val repository: UserRepository
 ) {
     suspend operator fun invoke(): NetworkResult<Unit> {
-        return repository.deleteUserInfo()
+        return repository.removeUserInfo()
     }
 }

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageViewModel.kt
@@ -7,8 +7,8 @@ import com.yapp.growth.base.LoadState
 import com.yapp.growth.domain.onError
 import com.yapp.growth.domain.onSuccess
 import com.yapp.growth.domain.runCatching
-import com.yapp.growth.domain.usecase.DeleteUserInfoUseCase
 import com.yapp.growth.domain.usecase.GetUserInfoUseCase
+import com.yapp.growth.domain.usecase.RemoveUserInfoUseCase
 import com.yapp.growth.presentation.R
 import com.yapp.growth.presentation.ui.main.myPage.MyPageContract.LoginState
 import com.yapp.growth.presentation.ui.main.myPage.MyPageContract.MyPageEvent
@@ -22,7 +22,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val getUserInfoUseCase: GetUserInfoUseCase,
-    private val deleteUserInfoUseCase: DeleteUserInfoUseCase,
+    private val removeUserInfoUseCase: RemoveUserInfoUseCase,
     private val resourcesProvider: ResourceProvider,
     private val kakaoLoginSdk: LoginSdk
 ) : BaseViewModel<MyPageViewState, MyPageSideEffect, MyPageEvent>(MyPageViewState()) {
@@ -107,7 +107,7 @@ class MyPageViewModel @Inject constructor(
 
     private fun withdraw() {
         viewModelScope.launch {
-            deleteUserInfoUseCase.invoke()
+            removeUserInfoUseCase.invoke()
                 .onSuccess {
                     runCatching { kakaoLoginSdk.withdraw() }
                         .onSuccess {
@@ -127,7 +127,7 @@ class MyPageViewModel @Inject constructor(
         viewModelScope.launch {
             val cacheInfo = getUserInfoUseCase.getCachedUserInfo()
 
-            if(cacheInfo == null) {
+            if (cacheInfo == null) {
                 getUserInfoUseCase.invoke()
                     .onSuccess {
                         updateState {

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/myPage/MyPageViewModel.kt
@@ -8,6 +8,7 @@ import com.yapp.growth.domain.onError
 import com.yapp.growth.domain.onSuccess
 import com.yapp.growth.domain.runCatching
 import com.yapp.growth.domain.usecase.GetUserInfoUseCase
+import com.yapp.growth.domain.usecase.RemoveCachedUserInfoUseCase
 import com.yapp.growth.domain.usecase.RemoveUserInfoUseCase
 import com.yapp.growth.presentation.R
 import com.yapp.growth.presentation.ui.main.myPage.MyPageContract.LoginState
@@ -22,6 +23,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val getUserInfoUseCase: GetUserInfoUseCase,
+    private val removeCachedUserInfoUseCase: RemoveCachedUserInfoUseCase,
     private val removeUserInfoUseCase: RemoveUserInfoUseCase,
     private val resourcesProvider: ResourceProvider,
     private val kakaoLoginSdk: LoginSdk
@@ -97,6 +99,7 @@ class MyPageViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching { kakaoLoginSdk.logout() }
                 .onSuccess {
+                    removeCachedUserInfoUseCase.invoke()
                     sendEffect({ MyPageSideEffect.MoveToLogin })
                 }
                 .onError {


### PR DESCRIPTION
## ISSUE
- resolved #222 

<br>

## 작업 내용
- 로그아웃, 탈퇴 시 캐싱된 유저 데이터를 삭제하도록 수정
   - 이와 관련해 유즈케이스 생성
- **실제 검증 필요** (카카오 아이디가 없으요 ㅠ)

<br>

## Check List
- [x] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [x] CI/CD 통과 여부
- [ ] 1명 이상의 Approve 확인 후 Merge
- [x] 관련 이슈 연결
