### PR TITLE
[ISSUE-224] 월 이동 버튼의 리플 이펙트 범위를 변경

### DIFF
--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/createPlan/date/DateScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/createPlan/date/DateScreen.kt
@@ -2,6 +2,7 @@ package com.yapp.growth.presentation.ui.createPlan.date
 
 import android.content.Context
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,10 +18,12 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.SnackbarHost
 import androidx.compose.material.Text
 import androidx.compose.material.rememberScaffoldState
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -160,7 +163,11 @@ fun DateCalendar(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
-                modifier = Modifier.clickable { onMonthlyPreviousClick() },
+                modifier = Modifier.clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = rememberRipple(bounded = false),
+                    onClick = { onMonthlyPreviousClick() }
+                ),
                 tint = Color.Unspecified,
                 imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_box_left_24),
                 contentDescription = null,
@@ -172,7 +179,11 @@ fun DateCalendar(
             )
             Spacer(modifier = Modifier.width(16.dp))
             Icon(
-                modifier = Modifier.clickable { onMonthlyNextClick() },
+                modifier = Modifier.clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = rememberRipple(bounded = false),
+                    onClick = { onMonthlyNextClick() }
+                ),
                 tint = Color.Unspecified,
                 imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_box_right_24),
                 contentDescription = null,

--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/home/HomeScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -34,10 +35,12 @@ import androidx.compose.material.SnackbarHost
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.rememberScaffoldState
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -448,7 +451,11 @@ fun HomeMonthlyPlan(
                     Icon(
                         modifier = Modifier
                             .padding(start = 112.dp)
-                            .clickable { onPreviousClick() },
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = rememberRipple(bounded = false),
+                                onClick = { onPreviousClick() }
+                            ),
                         tint = Color.Unspecified,
                         imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_box_left_20),
                         contentDescription = null,
@@ -456,7 +463,11 @@ fun HomeMonthlyPlan(
                     Icon(
                         modifier = Modifier
                             .padding(start = 136.dp)
-                            .clickable { onNextClick() },
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = rememberRipple(bounded = false),
+                                onClick = { onNextClick() }
+                            ),
                         tint = Color.Unspecified,
                         imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_box_right_20),
                         contentDescription = null,


### PR DESCRIPTION
## ISSUE
- resolved #224 

<br>

## 작업 내용
- 홈 화면, 약속 선택 화면의 월 이동 버튼 클릭 시 둥근 리플 이펙트가 나타나도록 수정


<br>

## 실행 화면

- 첫 GIF에서 오늘의 약속 부분이 숫자가 이상하게 뜨는 것은 라이브 에디트로 인한 일시적 오류이니 넘어가주세요 :)

| Screen Shot | Screen Shot |
| ----------- | ----------- |
| ![1](https://user-images.githubusercontent.com/85336456/187627332-69e8d563-c6c1-44a2-9c8b-1228826631c9.gif)            |          ![2](https://user-images.githubusercontent.com/85336456/187627297-f724b175-21e3-4dd6-8647-d449f7b01b5b.gif)   |




<br>

## Check List
- [x] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [x] CI/CD 통과 여부
- [ ] 1명 이상의 Approve 확인 후 Merge
- [x] 관련 이슈 연결
