### PR TITLE
[ISSUE-227] 버튼 비활성화 시 리플 이펙트 보이지 않도록 수정

### DIFF
--- a/presentation/src/main/java/com/yapp/growth/presentation/component/PlanzButtons.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/component/PlanzButtons.kt
@@ -86,12 +86,13 @@ fun PlanzBasicButton(
 ) {
     Button(
         modifier = modifier.height(52.dp),
+        enabled = enabled,
         shape = RoundedCornerShape(10.dp),
-        onClick = { if (enabled) onClick() },
-        colors = when (enabled) {
-            true -> ButtonDefaults.buttonColors(backgroundColor = buttonColor)
-            else -> ButtonDefaults.buttonColors(backgroundColor = Gray300)
-        },
+        onClick = { onClick() },
+        colors = ButtonDefaults.buttonColors(
+            backgroundColor = buttonColor,
+            disabledBackgroundColor = Gray300
+        ),
         elevation = null,
     ) {
         Text(
@@ -113,12 +114,13 @@ fun PlanzBasicBottomButton(
 ) {
     Button(
         modifier = modifier.height(44.dp),
+        enabled = enabled,
         shape = RoundedCornerShape(6.dp),
-        onClick = { if (enabled) onClick() },
-        colors = when (enabled) {
-            true -> ButtonDefaults.buttonColors(backgroundColor = buttonColor)
-            else -> ButtonDefaults.buttonColors(backgroundColor = Gray300)
-        },
+        onClick = { onClick() },
+        colors = ButtonDefaults.buttonColors(
+            backgroundColor = buttonColor,
+            disabledBackgroundColor = Gray300
+        ),
         elevation = null,
     ) {
         Text(


### PR DESCRIPTION
## ISSUE
- resolved #227 

<br>

## 작업 내용
- 버튼 비활성화 시 버튼 컴포넌트의 enable을 false로 처리하고 disabled color 지정


<br>

## 실행 화면

| Screen Shot | Screen Shot |
| ----------- | ----------- |
|             |             |


<br>

## Check List
- [ ] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [ ] CI/CD 통과 여부
- [ ] 1명 이상의 Approve 확인 후 Merge
- [ ] 관련 이슈 연결
